### PR TITLE
fix: patch go-json decoder cache data race (issue #566 / PR #567)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/benitogf/jsondiff v0.0.0-20220926080659-c3db9b84b559
 	github.com/benitogf/jsonpatch v0.0.0-20260109052650-eec54232a9a2
 	github.com/getlantern/httptest v0.0.0-20161025015934-4b40f4c7e590
-	github.com/goccy/go-json v0.10.5
+	github.com/goccy/go-json v0.10.6
 	github.com/gorilla/handlers v1.5.2
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.3
@@ -30,3 +30,5 @@ require (
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/goccy/go-json => github.com/TelpeNight/goccy-go-json v0.10.6-0.20260107154047-6d231cc79430

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/TelpeNight/goccy-go-json v0.10.6-0.20260107154047-6d231cc79430 h1:BsWXLLU9PBze5abJ+DqrjAiMLIt0ot5yFALic1l++jc=
+github.com/TelpeNight/goccy-go-json v0.10.6-0.20260107154047-6d231cc79430/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/bclicn/color v0.0.0-20180711051946-108f2023dc84 h1:cutFptzj+ospnc1PETUqcSVTH3VQ44Bi0rpt3nE9gvo=
 github.com/bclicn/color v0.0.0-20180711051946-108f2023dc84/go.mod h1:Va9ap1qxjAWkIVaW1E9rH0aNgE8SDI5A4n8Ds8P0fAA=
 github.com/benitogf/coat v0.0.0-20200402073050-ff807656cbec h1:I2p/9YsiAMB+J2DrC+e7OvEWZCmpwolMQ23ejoEMFEE=
@@ -15,8 +17,6 @@ github.com/getlantern/httptest v0.0.0-20161025015934-4b40f4c7e590 h1:OhyiFx+yBN3
 github.com/getlantern/httptest v0.0.0-20161025015934-4b40f4c7e590/go.mod h1:rE/jidqqHHG9sjSxC24Gd5YCfZ1AT91C2wjJ28TAOfA=
 github.com/getlantern/mockconn v0.0.0-20200818071412-cb30d065a848 h1:2MhMMVBTnaHrst6HyWFDhwQCaJ05PZuOv1bE2gN8WFY=
 github.com/getlantern/mockconn v0.0.0-20200818071412-cb30d065a848/go.mod h1:+F5GJ7qGpQ03DBtcOEyQpM30ix4BLswdaojecFtsdy8=
-github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
-github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/gorilla/handlers v1.5.2 h1:cLTUSsNkgcwhgRqvCNmdbRWG0A3N4F+M2nWKdScwyEE=
 github.com/gorilla/handlers v1.5.2/go.mod h1:dX+xVpaxdSw+q0Qek8SSsl3dfMk3jNddUkMzo0GtH0w=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=

--- a/messages/messages_test.go
+++ b/messages/messages_test.go
@@ -1,7 +1,12 @@
 package messages
 
 import (
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/goccy/go-json"
@@ -123,4 +128,67 @@ func TestPatchInvalidMessage(t *testing.T) {
 func TestPatchListInvalidMessage(t *testing.T) {
 	_, _, err := PatchList([]byte(`invalid`), json.RawMessage(`[]`))
 	require.Error(t, err)
+}
+
+func TestGoJSONConcurrentDecoderInitNoPanic(t *testing.T) {
+	if os.Getenv("OOO_GOJSON_CHILD") == "1" {
+		runDecoderInitBurst()
+		return
+	}
+
+	// Under -race the Go toolchain compiles compile_race.go (mutex-protected),
+	// which is safe by design. The race we're guarding against only exists in
+	// the no-race build path, so skip the subprocess loop when -race is active.
+	if isRaceEnabled() {
+		t.Skip("race detector active: compile_race.go path is safe, skipping no-race stress test")
+	}
+
+	attempts := 30
+	if v := os.Getenv("OOO_GOJSON_STRESS_ATTEMPTS"); v != "" {
+		n, err := strconv.Atoi(v)
+		require.NoError(t, err)
+		attempts = n
+	}
+
+	for i := 0; i < attempts; i++ {
+		cmd := exec.Command(os.Args[0], "-test.run=^TestGoJSONConcurrentDecoderInitNoPanic$", "-test.count=1")
+		cmd.Env = append(os.Environ(), "OOO_GOJSON_CHILD=1")
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("go-json concurrent decoder init panicked on attempt %d/%d\n%s", i+1, attempts, string(output))
+		}
+	}
+}
+
+func runDecoderInitBurst() {
+	workers := runtime.GOMAXPROCS(0) * 16
+	if workers < 32 {
+		workers = 32
+	}
+	if v := os.Getenv("OOO_GOJSON_WORKERS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			workers = n
+		}
+	}
+
+	rounds := 800
+	payload := []byte(`{"data":{"key":"value"},"version":"v1","snapshot":true}`)
+
+	for i := 0; i < rounds; i++ {
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+
+		for w := 0; w < workers; w++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+
+				_, _ = DecodeBuffer(payload)
+			}()
+		}
+
+		close(start)
+		wg.Wait()
+	}
 }

--- a/messages/race_off_test.go
+++ b/messages/race_off_test.go
@@ -1,0 +1,5 @@
+//go:build !race
+
+package messages
+
+func isRaceEnabled() bool { return false }

--- a/messages/race_on_test.go
+++ b/messages/race_on_test.go
@@ -1,0 +1,5 @@
+//go:build race
+
+package messages
+
+func isRaceEnabled() bool { return true }


### PR DESCRIPTION
## Problem

The no-race build of go-json v0.10.6 writes `Decoder` interfaces to a shared slice without synchronization (`compile_norace.go`). Under concurrent first-time decode of the same type, one goroutine can read a torn interface — type word already written, data word still zero — producing a non-nil interface wrapping a nil `*structDecoder`. Calling `Decode()` on it panics:

```
(*structDecoder).Decode(0x0, ...) — SIGSEGV at struct.go:782
```

### Why `-race` does not catch it

go-json uses build tags to swap implementations: `compile_norace.go` (no locks, used in normal builds) vs `compile_race.go` (uses `sync.RWMutex`, used only with `-race`). The race detector exercises safer code — the racing code path never runs under `-race`.

### Upstream tracking
- Issue: https://github.com/goccy/go-json/issues/566
- Fix PR: https://github.com/goccy/go-json/pull/567 (open, not yet merged — maintainer citing intentional design)
- Prior report: https://github.com/goccy/go-json/issues/495

## Solution

Pin go-json to the atomic-safe fork commit from PR #567 via `go.mod replace` until upstream merges and tags a new release. The fix uses `atomic.Pointer` operations — benchmarks from PR #567 show it matches the no-race path exactly: `no_race: 0.69ns/op` vs `atomic: 0.70ns/op`.

## Regression guard

Added `TestGoJSONConcurrentDecoderInitNoPanic` in `messages/`. It spawns a fresh subprocess per attempt (resetting the decoder cache every time) and fires 32+ goroutines concurrently against `DecodeBuffer` to exercise the cold-init race window.

**Before patch:** panicked at attempt 2605/3000 — same signature as the production crash
**After patch:** 3000/3000 clean passes

```sh
# Default CI run (~13s locally, ~30s on 2-core CI runner)
go test ./messages -run TestGoJSONConcurrentDecoderInitNoPanic -count=1

# Deep local stress
OOO_GOJSON_STRESS_ATTEMPTS=3000 OOO_GOJSON_WORKERS=256 go test ./messages -run TestGoJSONConcurrentDecoderInitNoPanic -count=1
```

## Reverting when upstream fixes

Once https://github.com/goccy/go-json/pull/567 is merged and tagged:
1. Remove the `replace` directive from `go.mod`
2. Bump `require github.com/goccy/go-json` to the new tagged version
3. Run `go test ./messages -run TestGoJSONConcurrentDecoderInitNoPanic -count=1` — must pass without the replace