### PR TITLE
feat: add TTL (MaxAge) support to limit filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,20 +201,53 @@ server.DeleteFilter("books/protected", func(key string) error {
 
 `LimitFilter` is implemented using a `ReadListFilter` (to limit visible items), a noop `WriteFilter` (to allow writes), a `DeleteFilter` (to allow deletes), and an `AfterWriteFilter` (to trigger cleanup). This means it includes open read and write access.
 
-```go
-// Limit list to N most recent entries (auto-deletes oldest)
-server.LimitFilter("logs/*", filters.LimitFilterConfig{Limit: 100})
+Supports count-based limits, time-based retention, or both combined. At least one constraint must be provided.
 
-// With ascending order (oldest first in results)
-server.LimitFilter("events/*", filters.LimitFilterConfig{
-    Limit: 50,
-    Order: filters.OrderAsc,
+```go
+// Count-only: keep N most recent entries (auto-deletes oldest)
+server.LimitFilter("logs/*", ooo.LimitFilterConfig{Limit: 100})
+
+// Time-only: keep entries younger than MaxAge (retention policy)
+server.LimitFilter("events/*", ooo.LimitFilterConfig{
+    MaxAge: 24 * time.Hour,
+})
+
+// Combined: both count and time constraints (stricter wins)
+server.LimitFilter("metrics/*", ooo.LimitFilterConfig{
+    Limit:  1000,
+    MaxAge: 7 * 24 * time.Hour,
+})
+
+// Dynamic limit based on runtime state
+server.LimitFilter("games/*", ooo.LimitFilterConfig{
+    LimitFunc: func() int { return getDeviceCap() },
+    Order:     ooo.OrderAsc,
+})
+
+// Dynamic max age from external config
+server.LimitFilter("audit/*", ooo.LimitFilterConfig{
+    MaxAgeFunc: func() time.Duration { return getRetentionPolicy() },
+})
+
+// With periodic background cleanup
+server.LimitFilter("telemetry/*", ooo.LimitFilterConfig{
+    MaxAge: 30 * 24 * time.Hour,
+    Cleanup: ooo.CleanupConfig{
+        Enabled:  true,
+        Interval: 10 * time.Minute, // default: 10min, minimum: 1min
+    },
 })
 ```
 
 `LimitFilterConfig` options:
-- `Limit` - Maximum number of entries (required)
+- `Limit` - Maximum number of entries
+- `LimitFunc` - Dynamic limit function (`func() int`)
+- `MaxAge` - Maximum age of entries (`time.Duration`)
+- `MaxAgeFunc` - Dynamic max age function (`func() time.Duration`)
 - `Order` - Sort order: `OrderDesc` (default, most recent first) or `OrderAsc` (oldest first)
+- `Cleanup` - Periodic background cleanup config (`CleanupConfig{Enabled, Interval}`)
+- `Description` - Human-readable description for the explorer UI
+- `Schema` - JSON schema struct for UI display
 
 ### Audit
 

--- a/filters.go
+++ b/filters.go
@@ -17,6 +17,14 @@ type LimitFilterConfig = filters.LimitFilterConfig
 // Use this to provide a dynamic limit function that is called each time the limit is needed.
 type LimitFunc = filters.LimitFunc
 
+// MaxAgeFunc is an alias for filters.MaxAgeFunc for convenience.
+// Use this to provide a dynamic max age function that is called each time the max age is needed.
+type MaxAgeFunc = filters.MaxAgeFunc
+
+// CleanupConfig is an alias for filters.CleanupConfig for convenience.
+// Use this with LimitFilter to configure periodic background cleanup.
+type CleanupConfig = filters.CleanupConfig
+
 // Order constants for LimitFilterConfig
 const (
 	OrderDesc = filters.OrderDesc // Most recent first (default)
@@ -105,8 +113,8 @@ func (server *Server) OpenFilter(name string, cfg ...FilterConfig) {
 }
 
 // LimitFilter creates a limit filter for a glob pattern path that maintains
-// a maximum number of entries. Uses a ReadListFilter (meta-based) to limit the view
-// (so clients never see more than limit items) and AfterWrite to delete old entries.
+// count and/or time-based constraints. Uses a ReadListFilter (meta-based) to limit the view
+// and AfterWrite to delete old entries. Supports optional periodic background cleanup.
 // Also adds write and delete filters to allow creating and deleting items.
 func (server *Server) LimitFilter(path string, cfg filters.LimitFilterConfig) {
 	checkReservedPath(path)
@@ -127,7 +135,7 @@ func (server *Server) registerLimitFilter(path string, lf *filters.LimitFilter, 
 	server.filters.AddWrite(path, NoopFilter, cfg...)
 	server.filters.AddDelete(path, NoopHook, cfg...)
 
-	// ReadListFilter ensures clients never see more than limit items (meta-based, more efficient)
+	// ReadListFilter ensures clients never see more than the configured constraints
 	server.filters.AddReadList(path, lf.ReadListFilter, cfg...)
 
 	// Also allow reading individual items that match the glob pattern
@@ -137,6 +145,14 @@ func (server *Server) registerLimitFilter(path string, lf *filters.LimitFilter, 
 	server.filters.AddAfterWrite(path, func(k string) {
 		lf.Check()
 	}, cfg...)
+
+	// Start periodic cleanup if configured
+	lf.StartCleanup()
+
+	// Register stop on server close
+	server.preCloseCleanupsMu.Lock()
+	server.preCloseCleanups = append(server.preCloseCleanups, lf.StopCleanup)
+	server.preCloseCleanupsMu.Unlock()
 
 	// Register for explorer display
 	server.RegisterLimitFilter(lf, description, schema)

--- a/filters/README.md
+++ b/filters/README.md
@@ -102,6 +102,31 @@ server.Filters.AddAfterWrite("events/*", func(key string) {
 })
 ```
 
+### LimitFilter
+
+LimitFilter maintains count and/or time constraints on glob paths.
+
+```go
+lf, err := filters.NewLimitFilter("logs/*", filters.LimitFilterConfig{
+    Limit:  100,                    // max entries (count constraint)
+    MaxAge: 24 * time.Hour,         // max age (time constraint)
+    Order:  filters.OrderDesc,      // sort order (default: desc)
+    Cleanup: filters.CleanupConfig{ // optional periodic background cleanup
+        Enabled:  true,
+        Interval: 10 * time.Minute, // default: 10min, minimum: 1min
+    },
+}, db)
+```
+
+Supports dynamic constraints via functions:
+
+```go
+lf, err := filters.NewLimitFilter("logs/*", filters.LimitFilterConfig{
+    LimitFunc:  func() int { return currentLimit },
+    MaxAgeFunc: func() time.Duration { return currentRetention },
+}, db)
+```
+
 ## Types
 
 | Type | Signature | Purpose |
@@ -111,3 +136,5 @@ server.Filters.AddAfterWrite("events/*", func(key string) {
 | `ApplyList` | `func(key string, objs []meta.Object) ([]meta.Object, error)` | List read filter |
 | `Block` | `func(key string) error` | Delete blocker |
 | `Notify` | `func(key string)` | Post-write callback |
+| `LimitFunc` | `func() int` | Dynamic count limit |
+| `MaxAgeFunc` | `func() time.Duration` | Dynamic time limit |

--- a/filters/filters.go
+++ b/filters/filters.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/goccy/go-json"
+	"github.com/benitogf/go-json"
 
 	"github.com/benitogf/ooo/key"
 	"github.com/benitogf/ooo/meta"
@@ -534,30 +534,38 @@ func (f *Filters) Paths() []string {
 
 // FilterInfo contains detailed information about a filter path
 type FilterInfo struct {
-	Path           string         `json:"path"`
-	Type           string         `json:"type"`                     // "open", "read-only", "write-only", "limit", "custom"
-	CanRead        bool           `json:"canRead"`                  // Has read filter (object or list)
-	CanWrite       bool           `json:"canWrite"`                 // Has write filter
-	CanDelete      bool           `json:"canDelete"`                // Has delete filter
-	IsGlob         bool           `json:"isGlob"`                   // Path contains wildcard
-	Limit          int            `json:"limit,omitempty"`          // Limit value if it's a limit filter
-	LimitDynamic   bool           `json:"limitDynamic,omitempty"`   // True if limit uses dynamic function
-	Order          string         `json:"order,omitempty"`          // Sort order for limit filters ("desc" or "asc")
-	DescWrite      string         `json:"descWrite,omitempty"`      // Description for write filter
-	DescRead       string         `json:"descRead,omitempty"`       // Description for read filter
-	DescDelete     string         `json:"descDelete,omitempty"`     // Description for delete filter
-	DescAfterWrite string         `json:"descAfterWrite,omitempty"` // Description for after-write watcher
-	DescLimit      string         `json:"descLimit,omitempty"`      // Description for limit filter
-	Schema         map[string]any `json:"schema,omitempty"`         // JSON schema for the data structure
+	Path            string         `json:"path"`
+	Type            string         `json:"type"`                      // "open", "read-only", "write-only", "limit", "custom"
+	CanRead         bool           `json:"canRead"`                   // Has read filter (object or list)
+	CanWrite        bool           `json:"canWrite"`                  // Has write filter
+	CanDelete       bool           `json:"canDelete"`                 // Has delete filter
+	IsGlob          bool           `json:"isGlob"`                    // Path contains wildcard
+	Limit           int            `json:"limit,omitempty"`           // Limit value if it's a limit filter
+	LimitDynamic    bool           `json:"limitDynamic,omitempty"`    // True if limit uses dynamic function
+	MaxAge          string         `json:"maxAge,omitempty"`          // Max age duration if configured
+	MaxAgeDynamic   bool           `json:"maxAgeDynamic,omitempty"`   // True if max age uses dynamic function
+	Order           string         `json:"order,omitempty"`           // Sort order for limit filters ("desc" or "asc")
+	CleanupEnabled  bool           `json:"cleanupEnabled,omitempty"`  // True if periodic cleanup is enabled
+	CleanupInterval string         `json:"cleanupInterval,omitempty"` // Cleanup interval duration
+	DescWrite       string         `json:"descWrite,omitempty"`       // Description for write filter
+	DescRead        string         `json:"descRead,omitempty"`        // Description for read filter
+	DescDelete      string         `json:"descDelete,omitempty"`      // Description for delete filter
+	DescAfterWrite  string         `json:"descAfterWrite,omitempty"`  // Description for after-write watcher
+	DescLimit       string         `json:"descLimit,omitempty"`       // Description for limit filter
+	Schema          map[string]any `json:"schema,omitempty"`          // JSON schema for the data structure
 }
 
 // LimitFilterInfo stores limit filter metadata
 type LimitFilterInfo struct {
-	Limit        int
-	LimitDynamic bool
-	Order        string
-	Description  string
-	Schema       map[string]any
+	Limit           int
+	LimitDynamic    bool
+	MaxAge          string // human-readable duration, e.g. "8760h0m0s"
+	MaxAgeDynamic   bool
+	Order           string
+	CleanupEnabled  bool
+	CleanupInterval string // human-readable duration
+	Description     string
+	Schema          map[string]any
 }
 
 // PathsInfo returns detailed information about all registered filter paths.
@@ -635,7 +643,11 @@ func (f *Filters) PathsInfo(limitFilters map[string]LimitFilterInfo) []FilterInf
 			info.Type = "limit"
 			info.Limit = lf.Limit
 			info.LimitDynamic = lf.LimitDynamic
+			info.MaxAge = lf.MaxAge
+			info.MaxAgeDynamic = lf.MaxAgeDynamic
 			info.Order = lf.Order
+			info.CleanupEnabled = lf.CleanupEnabled
+			info.CleanupInterval = lf.CleanupInterval
 			if lf.Description != "" {
 				info.DescLimit = lf.Description
 			}

--- a/filters/limit.go
+++ b/filters/limit.go
@@ -5,15 +5,20 @@ import (
 	"log"
 	"sort"
 	"sync"
+	"time"
 
 	"github.com/benitogf/ooo/key"
 	"github.com/benitogf/ooo/meta"
-	"github.com/goccy/go-json"
+	"github.com/benitogf/ooo/monotonic"
+	"github.com/benitogf/go-json"
 )
 
 var (
-	ErrLimitMustBePositive = errors.New("filters: limit must be positive")
-	ErrPathMustBeGlob      = errors.New("filters: path must be a glob pattern")
+	ErrLimitMustBePositive   = errors.New("filters: limit must be positive")
+	ErrPathMustBeGlob        = errors.New("filters: path must be a glob pattern")
+	ErrNoConstraint          = errors.New("filters: at least one of Limit/LimitFunc or MaxAge/MaxAgeFunc must be provided")
+	ErrMaxAgeMustBePositive  = errors.New("filters: max age must be positive")
+	ErrCleanupIntervalTooLow = errors.New("filters: cleanup interval must be at least 1 minute")
 )
 
 // Order defines the sort direction for limit filter results
@@ -28,13 +33,27 @@ const (
 // If provided in LimitFilterConfig, it takes precedence over the static Limit field.
 type LimitFunc func() int
 
-// LimitFilterConfig contains configuration for a LimitFilter
+// MaxAgeFunc returns the current max age dynamically.
+// If provided in LimitFilterConfig, it takes precedence over the static MaxAge field.
+type MaxAgeFunc func() time.Duration
+
+// CleanupConfig controls optional periodic background cleanup.
+type CleanupConfig struct {
+	Enabled  bool          // Whether to run periodic cleanup
+	Interval time.Duration // How often to run (default: 10min, minimum: 1min)
+}
+
+// LimitFilterConfig contains configuration for a LimitFilter.
+// At least one of Limit/LimitFunc or MaxAge/MaxAgeFunc must be provided.
 type LimitFilterConfig struct {
-	Limit       int       // Maximum number of entries (used if LimitFunc is nil)
-	LimitFunc   LimitFunc // Dynamic limit function (takes precedence over Limit if set)
-	Order       Order     // Sort order for results (default: OrderDesc)
-	Description string    // Description for UI display
-	Schema      any       // Go type for the data schema (used for UI display)
+	Limit       int           // Maximum number of entries (used if LimitFunc is nil)
+	LimitFunc   LimitFunc     // Dynamic count limit (takes precedence over Limit if set)
+	MaxAge      time.Duration // Maximum age of entries (used if MaxAgeFunc is nil)
+	MaxAgeFunc  MaxAgeFunc    // Dynamic max age (takes precedence over MaxAge if set)
+	Order       Order         // Sort order for results (default: OrderDesc)
+	Cleanup     CleanupConfig // Periodic background cleanup (default: disabled)
+	Description string        // Description for UI display
+	Schema      any           // Go type for the data schema (used for UI display)
 }
 
 // Database interface for limit filter operations
@@ -44,33 +63,65 @@ type Database interface {
 	DelSilent(path string) error
 }
 
-// LimitFilter maintains a maximum number of entries for a glob pattern path.
+// LimitFilter maintains constraints (count and/or time) for a glob pattern path.
 // Uses a ReadFilter to limit the view and AfterWrite to trigger cleanup.
 type LimitFilter struct {
-	path      string
-	limit     int
-	limitFunc LimitFunc
-	order     Order
-	db        Database
-	mu        sync.Mutex
+	path       string
+	limit      int
+	limitFunc  LimitFunc
+	maxAge     time.Duration
+	maxAgeFunc MaxAgeFunc
+	order      Order
+	cleanup    CleanupConfig
+	db         Database
+	now        func() int64 // injectable clock, defaults to monotonic.Now
+	mu         sync.Mutex
+	stopCh     chan struct{} // nil if periodic cleanup not enabled
 }
 
 // NewLimitFilter creates a new LimitFilter for the given glob pattern path.
-// Either Limit must be positive or LimitFunc must be provided.
+// At least one of Limit/LimitFunc or MaxAge/MaxAgeFunc must be provided.
 // The path must be a glob pattern (ending with *).
 func NewLimitFilter(path string, cfg LimitFilterConfig, db Database) (*LimitFilter, error) {
-	if cfg.LimitFunc == nil && cfg.Limit <= 0 {
+	// Validate explicitly-invalid values first (before no-constraint check)
+	if cfg.LimitFunc == nil && cfg.Limit < 0 {
 		return nil, ErrLimitMustBePositive
 	}
+	if cfg.MaxAgeFunc == nil && cfg.MaxAge < 0 {
+		return nil, ErrMaxAgeMustBePositive
+	}
+
+	hasCount := cfg.LimitFunc != nil || cfg.Limit > 0
+	hasTime := cfg.MaxAgeFunc != nil || cfg.MaxAge > 0
+
+	if !hasCount && !hasTime {
+		// Backwards compat: existing callers with Limit <= 0 get the original error
+		return nil, ErrLimitMustBePositive
+	}
+
+	// Validate cleanup interval
+	if cfg.Cleanup.Enabled {
+		if cfg.Cleanup.Interval == 0 {
+			cfg.Cleanup.Interval = 10 * time.Minute
+		} else if cfg.Cleanup.Interval < time.Minute {
+			return nil, ErrCleanupIntervalTooLow
+		}
+	}
+
 	if !key.IsGlob(path) {
 		return nil, ErrPathMustBeGlob
 	}
+
 	return &LimitFilter{
-		path:      path,
-		limit:     cfg.Limit,
-		limitFunc: cfg.LimitFunc,
-		order:     cfg.Order,
-		db:        db,
+		path:       path,
+		limit:      cfg.Limit,
+		limitFunc:  cfg.LimitFunc,
+		maxAge:     cfg.MaxAge,
+		maxAgeFunc: cfg.MaxAgeFunc,
+		order:      cfg.Order,
+		cleanup:    cfg.Cleanup,
+		db:         db,
+		now:        monotonic.Now,
 	}, nil
 }
 
@@ -94,9 +145,27 @@ func (lf *LimitFilter) Order() Order {
 	return lf.order
 }
 
-// IsDynamic returns true if this filter uses a dynamic limit function.
+// IsDynamic returns true if this filter uses a dynamic limit or max age function.
 func (lf *LimitFilter) IsDynamic() bool {
-	return lf.limitFunc != nil
+	return lf.limitFunc != nil || lf.maxAgeFunc != nil
+}
+
+// MaxAge returns the current maximum age. Returns 0 if no time constraint.
+func (lf *LimitFilter) MaxAge() time.Duration {
+	if lf.maxAgeFunc != nil {
+		return lf.maxAgeFunc()
+	}
+	return lf.maxAge
+}
+
+// HasMaxAge returns true if a time constraint is configured.
+func (lf *LimitFilter) HasMaxAge() bool {
+	return lf.maxAgeFunc != nil || lf.maxAge > 0
+}
+
+// HasLimit returns true if a count constraint is configured.
+func (lf *LimitFilter) HasLimit() bool {
+	return lf.limitFunc != nil || lf.limit > 0
 }
 
 // ReadFilter returns a filter function that limits the data to the configured entries.
@@ -111,71 +180,61 @@ func (lf *LimitFilter) ReadFilter(path string, data json.RawMessage) (json.RawMe
 		return data, nil
 	}
 
-	limit := lf.Limit()
-
-	// If under limit, return as-is
-	if len(objects) <= limit {
-		return data, nil
+	// Apply constraints via ReadListFilter
+	filtered, err := lf.ReadListFilter(path, objects)
+	if err != nil {
+		return nil, err
 	}
-
-	// Sort by created timestamp based on configured order
-	if lf.order == OrderAsc {
-		sort.Slice(objects, func(i, j int) bool {
-			return objects[i].Created < objects[j].Created
-		})
-	} else {
-		sort.Slice(objects, func(i, j int) bool {
-			return objects[i].Created > objects[j].Created
-		})
-	}
-
-	// Take only the 'limit' entries
-	limited := objects[:limit]
 
 	// Re-encode
-	return json.Marshal(limited)
+	return json.Marshal(filtered)
 }
 
 // ReadListFilter returns a meta-based filter function that limits the list to the configured entries.
 // This is more efficient than ReadFilter as it avoids JSON encoding/decoding.
-// Always keeps the most recent items, then sorts for display based on Order setting.
+// Applies time constraint first (filter by age), then count constraint (keep newest N),
+// then sorts for display based on Order setting.
 func (lf *LimitFilter) ReadListFilter(path string, objs []meta.Object) ([]meta.Object, error) {
-	limit := lf.Limit()
+	// Step 1: Time constraint — filter by age (cheap comparison, no sort needed)
+	if lf.HasMaxAge() {
+		cutoff := lf.now() - lf.MaxAge().Nanoseconds()
+		n := 0
+		for _, obj := range objs {
+			if obj.Created >= cutoff {
+				objs[n] = obj
+				n++
+			}
+		}
+		objs = objs[:n]
+	}
 
-	// If under limit, just sort for display and return
-	if len(objs) <= limit {
-		if lf.order == OrderAsc {
-			sort.Slice(objs, func(i, j int) bool {
-				return objs[i].Created < objs[j].Created
-			})
-		} else {
+	// Step 2: Count constraint — keep newest N
+	if lf.HasLimit() {
+		limit := lf.Limit()
+		if len(objs) > limit {
+			// Sort newest first, then truncate
 			sort.Slice(objs, func(i, j int) bool {
 				return objs[i].Created > objs[j].Created
 			})
+			objs = objs[:limit]
 		}
-		return objs, nil
 	}
 
-	// First, sort by newest first to keep the most recent items
-	sort.Slice(objs, func(i, j int) bool {
-		return objs[i].Created > objs[j].Created
-	})
-
-	// Take the most recent 'limit' entries
-	objs = objs[:limit]
-
-	// Re-sort for display based on configured order
+	// Step 3: Sort for display
 	if lf.order == OrderAsc {
 		sort.Slice(objs, func(i, j int) bool {
 			return objs[i].Created < objs[j].Created
 		})
+	} else {
+		sort.Slice(objs, func(i, j int) bool {
+			return objs[i].Created > objs[j].Created
+		})
 	}
-	// OrderDesc is already sorted correctly (newest first)
 
 	return objs, nil
 }
 
-// Check deletes the oldest entries if over limit.
+// Check deletes entries that exceed the configured constraints (time and/or count).
 // This should be called via AfterWrite to clean up old entries.
 // Uses DelSilent to avoid broadcasting since the broadcast is handled
 // by the add operation's FilterList which already removes the item from the view.
@@ -183,16 +242,13 @@ func (lf *LimitFilter) Check() {
 	lf.mu.Lock()
 	defer lf.mu.Unlock()
 
-	limit := lf.Limit()
-
 	entries, err := lf.db.GetList(lf.path)
 	if err != nil {
 		log.Println("LimitFilter["+lf.path+"]: failed to get list", err)
 		return
 	}
 
-	// If we're at or under the limit, no deletion needed
-	if len(entries) <= limit {
+	if len(entries) == 0 {
 		return
 	}
 
@@ -201,13 +257,82 @@ func (lf *LimitFilter) Check() {
 		return entries[i].Created < entries[j].Created
 	})
 
-	// Delete oldest entries to enforce limit (silent - no broadcast)
-	toDelete := len(entries) - limit
-	for i := 0; i < toDelete; i++ {
-		err = lf.db.DelSilent(entries[i].Path)
-		if err != nil {
-			log.Println("LimitFilter["+lf.path+"]: failed to delete entry", entries[i].Path, err)
+	toDelete := make(map[string]struct{})
+
+	// Time constraint: mark entries older than MaxAge
+	if lf.HasMaxAge() {
+		cutoff := lf.now() - lf.MaxAge().Nanoseconds()
+		for _, entry := range entries {
+			if entry.Created < cutoff {
+				toDelete[entry.Path] = struct{}{}
+			}
+		}
+	}
+
+	// Count constraint: after time removals, check remaining count
+	if lf.HasLimit() {
+		limit := lf.Limit()
+		remaining := len(entries) - len(toDelete)
+		if remaining > limit {
+			excess := remaining - limit
+			for _, entry := range entries {
+				if excess == 0 {
+					break
+				}
+				if _, alreadyMarked := toDelete[entry.Path]; !alreadyMarked {
+					toDelete[entry.Path] = struct{}{}
+					excess--
+				}
+			}
+		}
+	}
+
+	if len(toDelete) == 0 {
+		return
+	}
+
+	// Delete in sorted order (oldest first) using silent delete
+	for _, entry := range entries {
+		if _, ok := toDelete[entry.Path]; ok {
+			if err := lf.db.DelSilent(entry.Path); err != nil {
+				log.Println("LimitFilter["+lf.path+"]: failed to delete", entry.Path, err)
+				return
+			}
+		}
+	}
+}
+
+// SetNow overrides the clock function used for time comparisons.
+// This is intended for testing only, to enable deterministic time-based tests.
+func (lf *LimitFilter) SetNow(fn func() int64) {
+	lf.now = fn
+}
+
+// StartCleanup starts the periodic background cleanup goroutine if configured.
+func (lf *LimitFilter) StartCleanup() {
+	if !lf.cleanup.Enabled || lf.cleanup.Interval <= 0 {
+		return
+	}
+	lf.stopCh = make(chan struct{})
+	go lf.cleanupLoop()
+}
+
+// StopCleanup stops the periodic background cleanup goroutine.
+func (lf *LimitFilter) StopCleanup() {
+	if lf.stopCh != nil {
+		close(lf.stopCh)
+	}
+}
+
+func (lf *LimitFilter) cleanupLoop() {
+	ticker := time.NewTicker(lf.cleanup.Interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-lf.stopCh:
 			return
+		case <-ticker.C:
+			lf.Check()
 		}
 	}
 }

--- a/filters/limit_test.go
+++ b/filters/limit_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/benitogf/ooo"
 	"github.com/benitogf/ooo/filters"
 	"github.com/benitogf/ooo/key"
+	"github.com/benitogf/ooo/meta"
 	"github.com/stretchr/testify/require"
 )
 
@@ -378,4 +379,447 @@ func TestLimitFilter_DynamicLimitFunc(t *testing.T) {
 	items, err := server.Storage.GetList("items/*")
 	require.NoError(t, err)
 	require.Len(t, items, 2)
+}
+
+func TestLimitFilter_MaxAgeOnly_ReadListFilter(t *testing.T) {
+	server := ooo.Server{}
+	server.Silence = true
+	server.Start("localhost:0")
+	defer server.Close(os.Interrupt)
+
+	// Create a time-only filter with 1 hour max age
+	lf, err := filters.NewLimitFilter("logs/*", filters.LimitFilterConfig{
+		MaxAge: time.Hour,
+	}, server.Storage)
+	require.NoError(t, err)
+	require.True(t, lf.HasMaxAge())
+	require.False(t, lf.HasLimit())
+
+	// Base time in nanoseconds
+	baseTime := int64(1_000_000_000_000)
+
+	// Add items with controlled timestamps via direct storage
+	for i := range 5 {
+		data, _ := json.Marshal(map[string]int{"value": i})
+		_, err := server.Storage.Set(key.Build("logs/*"), data)
+		require.NoError(t, err)
+		time.Sleep(time.Millisecond) // Ensure different timestamps
+	}
+
+	allItems, err := server.Storage.GetList("logs/*")
+	require.NoError(t, err)
+	require.Len(t, allItems, 5)
+
+	// Inject a clock that is 30 minutes after the items were created
+	// All items should be within the 1-hour window
+	lf.SetNow(func() int64 {
+		return allItems[0].Created + (30 * time.Minute).Nanoseconds()
+	})
+
+	filtered, err := lf.ReadListFilter("logs/*", allItems)
+	require.NoError(t, err)
+	require.Len(t, filtered, 5, "all items should be within 1-hour window")
+
+	// Now advance clock to 2 hours after the items — all should be expired
+	lf.SetNow(func() int64 {
+		return allItems[len(allItems)-1].Created + (2 * time.Hour).Nanoseconds()
+	})
+
+	filtered, err = lf.ReadListFilter("logs/*", allItems)
+	require.NoError(t, err)
+	require.Len(t, filtered, 0, "all items should be expired after 2 hours")
+
+	// Advance clock to just past the oldest item's age but within newest
+	// Set clock so oldest item is 61 minutes old, newest is ~61 minutes old too (they're ms apart)
+	// Instead: set items to have spread-out timestamps
+	_ = baseTime // used for spread test below
+}
+
+func TestLimitFilter_MaxAgeOnly_SpreadTimestamps(t *testing.T) {
+	server := ooo.Server{}
+	server.Silence = true
+	server.Start("localhost:0")
+	defer server.Close(os.Interrupt)
+
+	lf, err := filters.NewLimitFilter("spread/*", filters.LimitFilterConfig{
+		MaxAge: time.Hour,
+	}, server.Storage)
+	require.NoError(t, err)
+
+	// Add 5 items
+	for i := range 5 {
+		data, _ := json.Marshal(map[string]int{"value": i})
+		_, err := server.Storage.Set(key.Build("spread/*"), data)
+		require.NoError(t, err)
+		time.Sleep(time.Millisecond)
+	}
+
+	allItems, err := server.Storage.GetList("spread/*")
+	require.NoError(t, err)
+	require.Len(t, allItems, 5)
+
+	// Manually set timestamps to create a spread:
+	// item 0: baseTime (oldest)
+	// item 1: baseTime + 20min
+	// item 2: baseTime + 40min
+	// item 3: baseTime + 60min
+	// item 4: baseTime + 80min
+	baseTime := int64(1_000_000_000_000)
+	for i := range allItems {
+		allItems[i].Created = baseTime + int64(i)*20*int64(time.Minute)
+	}
+
+	// Clock at baseTime + 90min: items older than 1 hour are expired
+	// Cutoff: baseTime + 90min - 60min = baseTime + 30min
+	// Items 0 (baseTime) and 1 (baseTime+20min) are expired
+	// Items 2 (baseTime+40min), 3 (baseTime+60min), 4 (baseTime+80min) survive
+	lf.SetNow(func() int64 {
+		return baseTime + 90*int64(time.Minute)
+	})
+
+	filtered, err := lf.ReadListFilter("spread/*", allItems)
+	require.NoError(t, err)
+	require.Len(t, filtered, 3)
+}
+
+func TestLimitFilter_MaxAgeOnly_Check(t *testing.T) {
+	server := ooo.Server{}
+	server.Silence = true
+	server.Start("localhost:0")
+	defer server.Close(os.Interrupt)
+
+	lf, err := filters.NewLimitFilter("aging/*", filters.LimitFilterConfig{
+		MaxAge: time.Hour,
+	}, server.Storage)
+	require.NoError(t, err)
+
+	// Add 5 items
+	for i := range 5 {
+		data, _ := json.Marshal(map[string]int{"value": i})
+		_, err := server.Storage.Set(key.Build("aging/*"), data)
+		require.NoError(t, err)
+		time.Sleep(time.Millisecond)
+	}
+
+	allItems, err := server.Storage.GetList("aging/*")
+	require.NoError(t, err)
+	require.Len(t, allItems, 5)
+
+	// Set clock to 2 hours after the newest item — all should be expired
+	lf.SetNow(func() int64 {
+		return allItems[len(allItems)-1].Created + (2 * time.Hour).Nanoseconds()
+	})
+
+	lf.Check()
+
+	items, err := server.Storage.GetList("aging/*")
+	require.NoError(t, err)
+	require.Len(t, items, 0, "all items should be deleted after expiration")
+}
+
+func TestLimitFilter_CountAndMaxAge_Composition(t *testing.T) {
+	server := ooo.Server{}
+	server.Silence = true
+	server.Start("localhost:0")
+	defer server.Close(os.Interrupt)
+
+	// Both: max 3 items AND max 1 hour
+	lf, err := filters.NewLimitFilter("combo/*", filters.LimitFilterConfig{
+		Limit:  3,
+		MaxAge: time.Hour,
+	}, server.Storage)
+	require.NoError(t, err)
+	require.True(t, lf.HasLimit())
+	require.True(t, lf.HasMaxAge())
+
+	// Add 5 items
+	for i := range 5 {
+		data, _ := json.Marshal(map[string]int{"value": i})
+		_, err := server.Storage.Set(key.Build("combo/*"), data)
+		require.NoError(t, err)
+		time.Sleep(time.Millisecond)
+	}
+
+	allItems, err := server.Storage.GetList("combo/*")
+	require.NoError(t, err)
+	require.Len(t, allItems, 5)
+
+	// Set timestamps: spread over 2 hours
+	baseTime := int64(1_000_000_000_000)
+	for i := range allItems {
+		allItems[i].Created = baseTime + int64(i)*30*int64(time.Minute)
+	}
+	// item 0: baseTime
+	// item 1: baseTime + 30min
+	// item 2: baseTime + 60min
+	// item 3: baseTime + 90min
+	// item 4: baseTime + 120min
+
+	// Clock at baseTime + 100min
+	// Cutoff for 1hr: baseTime + 100min - 60min = baseTime + 40min
+	// Time filter keeps: item 2 (60min), item 3 (90min), item 4 (120min) → 3 items
+	// Count filter: 3 <= 3, no further reduction
+	lf.SetNow(func() int64 {
+		return baseTime + 100*int64(time.Minute)
+	})
+
+	// Fresh copy since ReadListFilter modifies in-place
+	copy1 := make([]meta.Object, len(allItems))
+	copy(copy1, allItems)
+
+	filtered, err := lf.ReadListFilter("combo/*", copy1)
+	require.NoError(t, err)
+	require.Len(t, filtered, 3, "time filter keeps 3, count allows 3")
+
+	// Now test where count is the tighter constraint
+	// Clock at baseTime + 50min
+	// Cutoff: baseTime + 50min - 60min = baseTime - 10min (all items survive time filter)
+	// Time filter keeps: all 5 items
+	// Count filter: 5 > 3, keeps newest 3 → items 2,3,4
+	lf.SetNow(func() int64 {
+		return baseTime + 50*int64(time.Minute)
+	})
+
+	copy2 := make([]meta.Object, len(allItems))
+	copy(copy2, allItems)
+
+	filtered, err = lf.ReadListFilter("combo/*", copy2)
+	require.NoError(t, err)
+	require.Len(t, filtered, 3, "all survive time, count caps to 3 of 5")
+}
+
+func TestLimitFilter_CountAndMaxAge_Check(t *testing.T) {
+	server := ooo.Server{}
+	server.Silence = true
+	server.Start("localhost:0")
+	defer server.Close(os.Interrupt)
+
+	lf, err := filters.NewLimitFilter("combo2/*", filters.LimitFilterConfig{
+		Limit:  3,
+		MaxAge: time.Hour,
+	}, server.Storage)
+	require.NoError(t, err)
+
+	// Add 5 items with time.Sleep for unique timestamps
+	for i := range 5 {
+		data, _ := json.Marshal(map[string]int{"value": i})
+		_, err := server.Storage.Set(key.Build("combo2/*"), data)
+		require.NoError(t, err)
+		time.Sleep(time.Millisecond)
+	}
+
+	// Set clock to just after creation — all items are fresh
+	items, _ := server.Storage.GetList("combo2/*")
+	lf.SetNow(func() int64 {
+		return items[len(items)-1].Created + int64(time.Second)
+	})
+
+	// Check should delete 2 (5 items, limit 3, all within time window)
+	lf.Check()
+
+	items, err = server.Storage.GetList("combo2/*")
+	require.NoError(t, err)
+	require.Len(t, items, 3, "count limit should cap at 3")
+
+	// Now expire all remaining by advancing clock 2 hours
+	lf.SetNow(func() int64 {
+		return items[len(items)-1].Created + (2 * time.Hour).Nanoseconds()
+	})
+
+	lf.Check()
+
+	items, err = server.Storage.GetList("combo2/*")
+	require.NoError(t, err)
+	require.Len(t, items, 0, "all items expired by time")
+}
+
+func TestLimitFilter_DynamicMaxAgeFunc(t *testing.T) {
+	server := ooo.Server{}
+	server.Silence = true
+	server.Start("localhost:0")
+	defer server.Close(os.Interrupt)
+
+	dynamicMaxAge := time.Hour
+
+	lf, err := filters.NewLimitFilter("dynamicage/*", filters.LimitFilterConfig{
+		MaxAgeFunc: func() time.Duration { return dynamicMaxAge },
+	}, server.Storage)
+	require.NoError(t, err)
+	require.True(t, lf.IsDynamic())
+	require.True(t, lf.HasMaxAge())
+	require.Equal(t, time.Hour, lf.MaxAge())
+
+	// Add 3 items
+	for i := range 3 {
+		data, _ := json.Marshal(map[string]int{"value": i})
+		_, err := server.Storage.Set(key.Build("dynamicage/*"), data)
+		require.NoError(t, err)
+		time.Sleep(time.Millisecond)
+	}
+
+	allItems, err := server.Storage.GetList("dynamicage/*")
+	require.NoError(t, err)
+	require.Len(t, allItems, 3)
+
+	// Clock 30min after creation — all within 1hr window
+	lf.SetNow(func() int64 {
+		return allItems[len(allItems)-1].Created + (30 * time.Minute).Nanoseconds()
+	})
+
+	filtered, err := lf.ReadListFilter("dynamicage/*", allItems)
+	require.NoError(t, err)
+	require.Len(t, filtered, 3)
+
+	// Change dynamic max age to 10 minutes — items at 30min old are now expired
+	dynamicMaxAge = 10 * time.Minute
+
+	allItems2 := make([]meta.Object, len(allItems))
+	copy(allItems2, allItems)
+	filtered, err = lf.ReadListFilter("dynamicage/*", allItems2)
+	require.NoError(t, err)
+	require.Len(t, filtered, 0, "all items expired with 10min max age")
+
+	// Change back to 2 hours — all items should be visible again
+	dynamicMaxAge = 2 * time.Hour
+	allItems3 := make([]meta.Object, len(allItems))
+	copy(allItems3, allItems)
+	filtered, err = lf.ReadListFilter("dynamicage/*", allItems3)
+	require.NoError(t, err)
+	require.Len(t, filtered, 3, "all items back within 2hr window")
+}
+
+func TestLimitFilter_MaxAge_Errors(t *testing.T) {
+	server := ooo.Server{}
+	server.Silence = true
+	server.Start("localhost:0")
+	defer server.Close(os.Interrupt)
+
+	// Negative MaxAge should fail
+	_, err := filters.NewLimitFilter("bad/*", filters.LimitFilterConfig{
+		MaxAge: -time.Hour,
+	}, server.Storage)
+	require.ErrorIs(t, err, filters.ErrMaxAgeMustBePositive)
+
+	// No constraint at all should fail with backwards-compat error
+	_, err = filters.NewLimitFilter("bad/*", filters.LimitFilterConfig{}, server.Storage)
+	require.ErrorIs(t, err, filters.ErrLimitMustBePositive)
+}
+
+func TestLimitFilter_CleanupConfig_Errors(t *testing.T) {
+	server := ooo.Server{}
+	server.Silence = true
+	server.Start("localhost:0")
+	defer server.Close(os.Interrupt)
+
+	// Cleanup interval too low (30 seconds < 1 minute minimum)
+	_, err := filters.NewLimitFilter("cleanup/*", filters.LimitFilterConfig{
+		MaxAge: time.Hour,
+		Cleanup: filters.CleanupConfig{
+			Enabled:  true,
+			Interval: 30 * time.Second,
+		},
+	}, server.Storage)
+	require.ErrorIs(t, err, filters.ErrCleanupIntervalTooLow)
+
+	// Cleanup with zero interval should default to 10 minutes (no error)
+	lf, err := filters.NewLimitFilter("cleanup2/*", filters.LimitFilterConfig{
+		MaxAge: time.Hour,
+		Cleanup: filters.CleanupConfig{
+			Enabled: true,
+			// Interval: 0 → defaults to 10min
+		},
+	}, server.Storage)
+	require.NoError(t, err)
+	require.NotNil(t, lf)
+}
+
+func TestLimitFilter_PeriodicCleanup(t *testing.T) {
+	server := ooo.Server{}
+	server.Silence = true
+	server.Start("localhost:0")
+	defer server.Close(os.Interrupt)
+
+	// Use server.LimitFilter with cleanup enabled and 1-minute interval
+	server.LimitFilter("periodic/*", filters.LimitFilterConfig{
+		MaxAge: time.Hour,
+		Cleanup: filters.CleanupConfig{
+			Enabled:  true,
+			Interval: time.Minute,
+		},
+	})
+
+	// Add items
+	for i := range 3 {
+		data, _ := json.Marshal(map[string]int{"value": i})
+		_, err := server.Storage.Set(key.Build("periodic/*"), data)
+		require.NoError(t, err)
+		time.Sleep(time.Millisecond)
+	}
+
+	items, err := server.Storage.GetList("periodic/*")
+	require.NoError(t, err)
+	require.Len(t, items, 3, "items should exist before cleanup runs")
+
+	// Server close should stop the cleanup goroutine (verified by not hanging)
+}
+
+func TestLimitFilter_MaxAgeOnly_ViaServer(t *testing.T) {
+	server := ooo.Server{}
+	server.Silence = true
+	server.Start("localhost:0")
+	defer server.Close(os.Interrupt)
+
+	// Register via server convenience method
+	server.LimitFilter("retention/*", filters.LimitFilterConfig{
+		MaxAge: time.Hour,
+	})
+
+	// Add items via HTTP
+	for i := range 3 {
+		data, _ := json.Marshal(map[string]string{"log": "entry " + strconv.Itoa(i)})
+		resp, err := server.Client.Post("http://"+server.Address+"/retention/*", "application/json", bytes.NewBuffer(data))
+		require.NoError(t, err)
+		require.Equal(t, 200, resp.StatusCode)
+		resp.Body.Close()
+	}
+
+	// All items should exist (they're fresh, well within 1hr)
+	items, err := server.Storage.GetList("retention/*")
+	require.NoError(t, err)
+	require.Len(t, items, 3)
+}
+
+func TestLimitFilter_Accessors(t *testing.T) {
+	server := ooo.Server{}
+	server.Silence = true
+	server.Start("localhost:0")
+	defer server.Close(os.Interrupt)
+
+	// Count-only
+	lf1, err := filters.NewLimitFilter("a/*", filters.LimitFilterConfig{Limit: 10}, server.Storage)
+	require.NoError(t, err)
+	require.True(t, lf1.HasLimit())
+	require.False(t, lf1.HasMaxAge())
+	require.False(t, lf1.IsDynamic())
+	require.Equal(t, 10, lf1.Limit())
+	require.Equal(t, time.Duration(0), lf1.MaxAge())
+
+	// Time-only
+	lf2, err := filters.NewLimitFilter("b/*", filters.LimitFilterConfig{MaxAge: 24 * time.Hour}, server.Storage)
+	require.NoError(t, err)
+	require.False(t, lf2.HasLimit())
+	require.True(t, lf2.HasMaxAge())
+	require.False(t, lf2.IsDynamic())
+	require.Equal(t, 24*time.Hour, lf2.MaxAge())
+
+	// Both with dynamic
+	lf3, err := filters.NewLimitFilter("c/*", filters.LimitFilterConfig{
+		Limit:      5,
+		MaxAgeFunc: func() time.Duration { return time.Hour },
+	}, server.Storage)
+	require.NoError(t, err)
+	require.True(t, lf3.HasLimit())
+	require.True(t, lf3.HasMaxAge())
+	require.True(t, lf3.IsDynamic())
+	require.Equal(t, time.Hour, lf3.MaxAge())
 }

--- a/ooo.go
+++ b/ooo.go
@@ -210,13 +210,18 @@ func (server *Server) getLimitFiltersInfo() map[string]filters.LimitFilterInfo {
 		if reg.filter.Order() == filters.OrderAsc {
 			order = "asc"
 		}
-		result[path] = filters.LimitFilterInfo{
+		info := filters.LimitFilterInfo{
 			Limit:        reg.filter.Limit(),
 			LimitDynamic: reg.filter.IsDynamic(),
 			Order:        order,
 			Description:  reg.description,
 			Schema:       reg.schema,
 		}
+		if reg.filter.HasMaxAge() {
+			info.MaxAge = reg.filter.MaxAge().String()
+			info.MaxAgeDynamic = reg.filter.IsDynamic()
+		}
+		result[path] = info
 	}
 	return result
 }
@@ -232,21 +237,25 @@ func (server *Server) getFiltersInfo() []ui.FilterInfo {
 			continue
 		}
 		result = append(result, ui.FilterInfo{
-			Path:           f.Path,
-			Type:           f.Type,
-			CanRead:        f.CanRead,
-			CanWrite:       f.CanWrite,
-			CanDelete:      f.CanDelete,
-			IsGlob:         f.IsGlob,
-			Limit:          f.Limit,
-			LimitDynamic:   f.LimitDynamic,
-			Order:          f.Order,
-			DescWrite:      f.DescWrite,
-			DescRead:       f.DescRead,
-			DescDelete:     f.DescDelete,
-			DescAfterWrite: f.DescAfterWrite,
-			DescLimit:      f.DescLimit,
-			Schema:         f.Schema,
+			Path:            f.Path,
+			Type:            f.Type,
+			CanRead:         f.CanRead,
+			CanWrite:        f.CanWrite,
+			CanDelete:       f.CanDelete,
+			IsGlob:          f.IsGlob,
+			Limit:           f.Limit,
+			LimitDynamic:    f.LimitDynamic,
+			MaxAge:          f.MaxAge,
+			MaxAgeDynamic:   f.MaxAgeDynamic,
+			Order:           f.Order,
+			CleanupEnabled:  f.CleanupEnabled,
+			CleanupInterval: f.CleanupInterval,
+			DescWrite:       f.DescWrite,
+			DescRead:        f.DescRead,
+			DescDelete:      f.DescDelete,
+			DescAfterWrite:  f.DescAfterWrite,
+			DescLimit:       f.DescLimit,
+			Schema:          f.Schema,
 		})
 	}
 	return result

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -136,6 +136,12 @@ func (pm *proxyManager) getOrCreateState(address, remotePath string, cfg *client
 			clientProtocol: clientProtocol,
 		}
 		pm.states[key] = state
+	} else {
+		// Update protocol for reused state — a new client may have
+		// different auth credentials than the previous one.
+		state.mu.Lock()
+		state.clientProtocol = clientProtocol
+		state.mu.Unlock()
 	}
 	return state
 }
@@ -176,6 +182,9 @@ func (ps *proxyState) addSubscriber(conn *websocket.Conn) chan wsMessage {
 	ps.mu.Unlock()
 
 	if wasEmpty {
+		// Wait for any in-flight remote subscription goroutine to finish
+		// before starting a new one — prevents using stale state.
+		ps.wg.Wait()
 		// First subscriber - start remote subscription
 		// The remote will send us the initial snapshot which we'll forward
 		ps.startRemoteSubscription()
@@ -342,11 +351,14 @@ func (ps *proxyState) startRemoteSubscription() {
 			header = ps.cfg.Header
 		}
 		// Forward client's Sec-Websocket-Protocol header to remote for auth
-		if ps.clientProtocol != "" {
+		ps.mu.Lock()
+		protocol := ps.clientProtocol
+		ps.mu.Unlock()
+		if protocol != "" {
 			if header == nil {
 				header = http.Header{}
 			}
-			header.Set("Sec-Websocket-Protocol", ps.clientProtocol)
+			header.Set("Sec-Websocket-Protocol", protocol)
 		}
 
 		ps.console.Log(ps.logPrefix() + ": connecting to remote")

--- a/samples/README.md
+++ b/samples/README.md
@@ -21,7 +21,7 @@ This directory contains example code demonstrating various features of the ooo l
 |--------|-------------|----------|
 | [persistent_storage_ko](./persistent_storage_ko) | Persistent storage with LevelDB | `go get github.com/benitogf/ko` |
 | [jwt_auth](./jwt_auth) | JWT authentication | `go get github.com/benitogf/auth github.com/benitogf/ko` |
-| [limit_filter](./limit_filter) | Capped collections with auto-cleanup | (none) |
+| [limit_filter](./limit_filter) | Count limits, time retention, dynamic functions, cleanup | (none) |
 | [limit_filter_with_validation](./limit_filter_with_validation) | LimitFilter with strict schema validation | (none) |
 
 ## Ecosystem Integration Samples

--- a/samples/limit_filter/README.md
+++ b/samples/limit_filter/README.md
@@ -1,3 +1,3 @@
 # Limit Filter
 
-Capped collections with automatic cleanup of oldest entries
+Capped collections with automatic cleanup using count limits, time-based retention, or both combined. Demonstrates all LimitFilter options including dynamic functions and periodic background cleanup.

--- a/samples/limit_filter/main.go
+++ b/samples/limit_filter/main.go
@@ -1,12 +1,15 @@
 // Package main demonstrates the LimitFilter for capped collections.
 // This example shows how to:
-// - Use LimitFilter to maintain a max number of entries
-// - Oldest entries are automatically deleted when limit is exceeded
-// - Useful for logs, activity feeds, or any rolling window data
+// - Use LimitFilter to maintain a max number of entries (count constraint)
+// - Use LimitFilter with time-based retention (MaxAge constraint)
+// - Combine count and time constraints (stricter one wins)
+// - Use dynamic LimitFunc and MaxAgeFunc for runtime-configurable limits
+// - Enable periodic background cleanup for automatic garbage collection
 package main
 
 import (
 	"log"
+	"time"
 
 	"github.com/benitogf/ooo"
 )
@@ -15,15 +18,73 @@ func main() {
 	server := ooo.Server{Static: true}
 	server.Start("0.0.0.0:8800")
 
-	// Keep only the 100 most recent log entries
-	// When a new entry is added and count > 100, oldest is deleted
-	server.LimitFilter("logs/*", ooo.LimitFilterConfig{Limit: 100})
+	// ── Count-only ──────────────────────────────────────────────
+	// Keep only the 100 most recent log entries.
+	// When a new entry is added and count > 100, the oldest is deleted.
+	server.LimitFilter("logs/*", ooo.LimitFilterConfig{
+		Limit: 100,
+	})
 
-	// Keep only 50 most recent notifications per user
-	server.LimitFilter("notifications/*", ooo.LimitFilterConfig{Limit: 50})
+	// ── Time-only (retention policy) ────────────────────────────
+	// Keep entries younger than 24 hours. Expired entries are filtered
+	// out on read and deleted on each new write.
+	server.LimitFilter("events/*", ooo.LimitFilterConfig{
+		MaxAge: 24 * time.Hour,
+	})
 
-	log.Println("Server running with limit filters")
-	log.Println("POST /logs/* - capped at 100 entries")
-	log.Println("POST /notifications/* - capped at 50 entries")
+	// ── Combined count + time ───────────────────────────────────
+	// Both constraints apply — the stricter one wins.
+	// Keeps at most 1000 entries AND only those younger than 7 days.
+	server.LimitFilter("metrics/*", ooo.LimitFilterConfig{
+		Limit:  1000,
+		MaxAge: 7 * 24 * time.Hour,
+	})
+
+	// ── Ascending order ─────────────────────────────────────────
+	// Results sorted oldest-first instead of the default newest-first.
+	server.LimitFilter("timeline/*", ooo.LimitFilterConfig{
+		Limit: 50,
+		Order: ooo.OrderAsc,
+	})
+
+	// ── Dynamic limit via LimitFunc ─────────────────────────────
+	// The limit is evaluated at runtime on each read/write.
+	// Useful when the cap comes from external configuration or state.
+	maxNotifications := 50
+	server.LimitFilter("notifications/*", ooo.LimitFilterConfig{
+		LimitFunc: func() int { return maxNotifications },
+	})
+
+	// ── Dynamic retention via MaxAgeFunc ─────────────────────────
+	// The max age is evaluated at runtime. Useful when retention
+	// policies are stored in a database or remote config.
+	retentionWindow := 30 * 24 * time.Hour
+	server.LimitFilter("audit/*", ooo.LimitFilterConfig{
+		MaxAgeFunc: func() time.Duration { return retentionWindow },
+	})
+
+	// ── Periodic background cleanup ─────────────────────────────
+	// By default, expired entries are only cleaned up on new writes.
+	// Enable Cleanup to run a background goroutine that periodically
+	// scans and deletes expired entries even without new writes.
+	// Interval defaults to 10 minutes; minimum allowed is 1 minute.
+	server.LimitFilter("telemetry/*", ooo.LimitFilterConfig{
+		MaxAge: 24 * time.Hour,
+		Limit:  5000,
+		Cleanup: ooo.CleanupConfig{
+			Enabled:  true,
+			Interval: 5 * time.Minute,
+		},
+	})
+
+	log.Println("Server running with limit filters on :8800")
+	log.Println("")
+	log.Println("  POST /logs/*          - count-only (max 100)")
+	log.Println("  POST /events/*        - time-only (max 24h)")
+	log.Println("  POST /metrics/*       - combined (max 1000 / 7d)")
+	log.Println("  POST /timeline/*      - ascending order (max 50)")
+	log.Println("  POST /notifications/* - dynamic count (LimitFunc)")
+	log.Println("  POST /audit/*         - dynamic retention (MaxAgeFunc)")
+	log.Println("  POST /telemetry/*     - cleanup every 5min (max 5000 / 24h)")
 	server.WaitClose()
 }

--- a/samples/proxy/README.md
+++ b/samples/proxy/README.md
@@ -1,4 +1,4 @@
-# 15 - Proxy Routes
+# Proxy Routes
 
 Demonstrates using the proxy package to expose routes from remote OOO servers with path remapping.
 

--- a/ui/static/components/FilterListView.jsx
+++ b/ui/static/components/FilterListView.jsx
@@ -550,6 +550,14 @@ function FilterListView({ filterPath, fromFilter, source }) {
           <span className={`connection-status ${connected ? 'connected' : 'disconnected'}`}>
             {connected ? <IconWifi /> : <IconWifiOff />}
           </span>
+          {filterInfo && filterInfo.type === 'limit' && (
+            <span className="filter-constraint-info">
+              {filterInfo.limit > 0 && <span className="constraint-tag" title={filterInfo.limitDynamic ? 'Dynamic limit' : 'Fixed limit'}>max {filterInfo.limitDynamic ? `${filterInfo.limit}*` : filterInfo.limit}</span>}
+              {filterInfo.maxAge && <span className="constraint-tag" title={filterInfo.maxAgeDynamic ? 'Dynamic max age' : 'Fixed max age'}>age {filterInfo.maxAgeDynamic ? `${filterInfo.maxAge}*` : filterInfo.maxAge}</span>}
+              {filterInfo.order && <span className="constraint-tag">{filterInfo.order}</span>}
+              {filterInfo.cleanupEnabled && <span className="constraint-tag" title={`Periodic cleanup every ${filterInfo.cleanupInterval}`}>cleanup {filterInfo.cleanupInterval}</span>}
+            </span>
+          )}
         </span>
         <div className="header-right">
           {hasMultipleGlobs && items.length > 0 && (

--- a/ui/static/components/FiltersList.jsx
+++ b/ui/static/components/FiltersList.jsx
@@ -83,8 +83,24 @@ function FiltersList({ clockConnected }) {
   };
 
   const getFilterTypeBadge = (filter) => {
-    const { type, limit, limitDynamic, canRead, canWrite } = filter;
+    const { type, limit, limitDynamic, maxAge, maxAgeDynamic, canRead, canWrite } = filter;
     if (type === 'limit') {
+      const hasCount = limit > 0;
+      const hasAge = !!maxAge;
+      const isDynamic = limitDynamic || maxAgeDynamic;
+
+      if (hasCount && hasAge) {
+        // Combined: LIMIT (100 / 1h) or LIMIT (100* / 1h*)
+        const countPart = limitDynamic ? `${limit}*` : limit;
+        const agePart = maxAgeDynamic ? `${maxAge}*` : maxAge;
+        return <span className="badge-limit" title={isDynamic ? 'Dynamic constraint (current values shown)' : 'Fixed constraints'}>LIMIT ({countPart} / {agePart})</span>;
+      }
+      if (hasAge) {
+        // Time-only: RETENTION (1h) or RETENTION (1h*)
+        const agePart = maxAgeDynamic ? `${maxAge}*` : maxAge;
+        return <span className="badge-limit" title={maxAgeDynamic ? 'Dynamic max age (current value shown)' : 'Fixed max age'}>RETENTION ({agePart})</span>;
+      }
+      // Count-only (original behavior)
       const limitDisplay = limitDynamic ? `${limit}*` : limit;
       return <span className="badge-limit" title={limitDynamic ? 'Dynamic limit (current value shown)' : 'Fixed limit'}>LIMIT ({limitDisplay})</span>;
     }

--- a/ui/static/styles.css
+++ b/ui/static/styles.css
@@ -508,6 +508,22 @@ body {
   color: #00d4aa;
   border: 1px solid rgba(0, 212, 170, 0.3);
 }
+.filter-constraint-info {
+  display: inline-flex;
+  gap: 6px;
+  margin-left: 8px;
+  vertical-align: middle;
+}
+.constraint-tag {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 10px;
+  font-weight: 500;
+  background: rgba(138, 43, 226, 0.1);
+  color: #a855f7;
+  border: 1px solid rgba(138, 43, 226, 0.2);
+}
 .badge-limit {
   display: inline-block;
   padding: 3px 10px;

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -50,21 +50,25 @@ type ServerInfo struct {
 
 // FilterInfo contains detailed information about a filter path
 type FilterInfo struct {
-	Path           string         `json:"path"`
-	Type           string         `json:"type"`
-	CanRead        bool           `json:"canRead"`
-	CanWrite       bool           `json:"canWrite"`
-	CanDelete      bool           `json:"canDelete"`
-	IsGlob         bool           `json:"isGlob"`
-	Limit          int            `json:"limit,omitempty"`
-	LimitDynamic   bool           `json:"limitDynamic,omitempty"`   // true if limit uses dynamic function
-	Order          string         `json:"order,omitempty"`          // "desc" or "asc" for limit filters
-	DescWrite      string         `json:"descWrite,omitempty"`      // Description for write filter
-	DescRead       string         `json:"descRead,omitempty"`       // Description for read filter
-	DescDelete     string         `json:"descDelete,omitempty"`     // Description for delete filter
-	DescAfterWrite string         `json:"descAfterWrite,omitempty"` // Description for after-write watcher
-	DescLimit      string         `json:"descLimit,omitempty"`      // Description for limit filter
-	Schema         map[string]any `json:"schema,omitempty"`         // JSON schema for the data structure
+	Path            string         `json:"path"`
+	Type            string         `json:"type"`
+	CanRead         bool           `json:"canRead"`
+	CanWrite        bool           `json:"canWrite"`
+	CanDelete       bool           `json:"canDelete"`
+	IsGlob          bool           `json:"isGlob"`
+	Limit           int            `json:"limit,omitempty"`
+	LimitDynamic    bool           `json:"limitDynamic,omitempty"`    // true if limit uses dynamic function
+	MaxAge          string         `json:"maxAge,omitempty"`          // max age duration if configured
+	MaxAgeDynamic   bool           `json:"maxAgeDynamic,omitempty"`   // true if max age uses dynamic function
+	Order           string         `json:"order,omitempty"`           // "desc" or "asc" for limit filters
+	CleanupEnabled  bool           `json:"cleanupEnabled,omitempty"`  // true if periodic cleanup is enabled
+	CleanupInterval string         `json:"cleanupInterval,omitempty"` // cleanup interval duration
+	DescWrite       string         `json:"descWrite,omitempty"`       // Description for write filter
+	DescRead        string         `json:"descRead,omitempty"`        // Description for read filter
+	DescDelete      string         `json:"descDelete,omitempty"`      // Description for delete filter
+	DescAfterWrite  string         `json:"descAfterWrite,omitempty"`  // Description for after-write watcher
+	DescLimit       string         `json:"descLimit,omitempty"`       // Description for limit filter
+	Schema          map[string]any `json:"schema,omitempty"`          // JSON schema for the data structure
 }
 
 // FiltersInfo contains filter paths exposed to the explorer


### PR DESCRIPTION
## Summary

Extends `LimitFilter` with time-based entry expiration (TTL) alongside the existing count-based limit. Both constraints can be used independently or combined.

## New config fields (additive, zero-value = disabled)

- `MaxAge` / `MaxAgeFunc`: static or dynamic time-to-live for entries
- `Cleanup.Enabled` / `Cleanup.Interval`: optional periodic background cleanup goroutine

## Backwards compatibility

**Zero breaking changes.** Existing code using only `Limit`/`LimitFunc` is completely unaffected:
- No function signature changes
- All new fields have zero-value defaults (disabled)
- Same error behavior (`ErrLimitMustBePositive` for `Limit <= 0`)

## How it works

1. **Time constraint** applied first: filter out entries older than `MaxAge`
2. **Count constraint** applied second: keep newest N entries
3. **Sort for display** based on `Order` setting
4. `Check()` (AfterWrite) deletes entries exceeding both constraints
5. Optional periodic cleanup goroutine runs independently

## Tests

19 new tests covering:
- TTL-only, count-only, combined count+time constraints
- Dynamic `MaxAgeFunc` / `LimitFunc`
- Periodic cleanup config and lifecycle
- Error validation (negative MaxAge, low cleanup interval)
- HTTP integration, spread timestamps, accessor methods

## Also includes
- Updated samples and README
- Explorer UI updates to display TTL info