### PR TITLE
Add watch() panic recovery with observability, drop goccy/go-json

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.25
 require (
 	github.com/benitogf/coat v0.0.0-20200402073050-ff807656cbec
 	github.com/benitogf/go-json v0.0.0-20260410172501-727f5690408b
-	github.com/benitogf/jsondiff v0.0.0-20220926080659-c3db9b84b559
-	github.com/benitogf/jsonpatch v0.0.0-20260109052650-eec54232a9a2
+	github.com/benitogf/jsondiff v0.0.0-20260413094925-a4be838c278b
+	github.com/benitogf/jsonpatch v0.0.0-20260413094158-a4a6cc1a3382
 	github.com/getlantern/httptest v0.0.0-20161025015934-4b40f4c7e590
 	github.com/gorilla/handlers v1.5.2
 	github.com/gorilla/mux v1.8.1
@@ -23,7 +23,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/getlantern/mockconn v0.0.0-20200818071412-cb30d065a848 // indirect
-	github.com/goccy/go-json v0.9.11 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/tidwall/match v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,10 +4,10 @@ github.com/benitogf/coat v0.0.0-20200402073050-ff807656cbec h1:I2p/9YsiAMB+J2DrC
 github.com/benitogf/coat v0.0.0-20200402073050-ff807656cbec/go.mod h1:hl/Xd8DKuMgC/ClZ2dPZz6mvXaxdkjrt0mr0+jF4UkQ=
 github.com/benitogf/go-json v0.0.0-20260410172501-727f5690408b h1:EXDsF3gMYyR8ipJsGuyHB4d3+XovPT8d4UM6cfBII14=
 github.com/benitogf/go-json v0.0.0-20260410172501-727f5690408b/go.mod h1:bv78ZxbWzHLAwEcSgQNjDUVgl3F4nOuYln98xHfUyjw=
-github.com/benitogf/jsondiff v0.0.0-20220926080659-c3db9b84b559 h1:0ERndS9JkEvEq/yXjiZq41lMb3QfmQWUIXycjkRbWOc=
-github.com/benitogf/jsondiff v0.0.0-20220926080659-c3db9b84b559/go.mod h1:gg2qmcNCGq/FXh5kQpsaEIf6GebYe2JMKrDSqZkuImc=
-github.com/benitogf/jsonpatch v0.0.0-20260109052650-eec54232a9a2 h1:OC5ZiOG0sQ5Qmp5XOA3iIBBjhDjze010jHicNTD27kU=
-github.com/benitogf/jsonpatch v0.0.0-20260109052650-eec54232a9a2/go.mod h1:O1Z+hTPUrXzHUjmKlpmNYK9wcncZ5rS3K8PqItDO0x0=
+github.com/benitogf/jsondiff v0.0.0-20260413094925-a4be838c278b h1:u7JAhkxSL5nMmH0HbpIg9w6qs7CYpdXiOiYemC3Zodo=
+github.com/benitogf/jsondiff v0.0.0-20260413094925-a4be838c278b/go.mod h1:u6UwX3TEBaFuJVD3NuCdMp3RyPsb71DxRdMptVDwTaA=
+github.com/benitogf/jsonpatch v0.0.0-20260413094158-a4a6cc1a3382 h1:invi4tSUoH4HMxFbM65sA3osc0wk9j3Za2JmtIqFRJc=
+github.com/benitogf/jsonpatch v0.0.0-20260413094158-a4a6cc1a3382/go.mod h1:ZOQm93UFJwYDZLHQVGt2/JmNOltb6LRIJUuys0uMWKY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -17,8 +17,6 @@ github.com/getlantern/httptest v0.0.0-20161025015934-4b40f4c7e590 h1:OhyiFx+yBN3
 github.com/getlantern/httptest v0.0.0-20161025015934-4b40f4c7e590/go.mod h1:rE/jidqqHHG9sjSxC24Gd5YCfZ1AT91C2wjJ28TAOfA=
 github.com/getlantern/mockconn v0.0.0-20200818071412-cb30d065a848 h1:2MhMMVBTnaHrst6HyWFDhwQCaJ05PZuOv1bE2gN8WFY=
 github.com/getlantern/mockconn v0.0.0-20200818071412-cb30d065a848/go.mod h1:+F5GJ7qGpQ03DBtcOEyQpM30ix4BLswdaojecFtsdy8=
-github.com/goccy/go-json v0.9.11 h1:/pAaQDLHEoCq/5FFmSKBswWmK6H0e8g4159Kc/X/nqk=
-github.com/goccy/go-json v0.9.11/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/gorilla/handlers v1.5.2 h1:cLTUSsNkgcwhgRqvCNmdbRWG0A3N4F+M2nWKdScwyEE=
 github.com/gorilla/handlers v1.5.2/go.mod h1:dX+xVpaxdSw+q0Qek8SSsl3dfMk3jNddUkMzo0GtH0w=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=

--- a/ooo.go
+++ b/ooo.go
@@ -149,6 +149,7 @@ type Server struct {
 	BeforeRead         func(key string)
 	GetPivotInfo       func() *ui.PivotInfo // Optional: returns pivot status for UI
 	NoCompress         bool                 // Disable gzip compression (useful for tests)
+	WatchPanics        int64                // Atomic counter of panics recovered in watch goroutines
 	startErr           chan error           // channel for startup errors
 	clockStop          chan struct{}        // channel to signal clock goroutine to stop
 }
@@ -184,6 +185,7 @@ func (server *Server) getServerInfo() ui.ServerInfo {
 		Silence:           server.Silence,
 		Workers:           server.Workers,
 		Tick:              server.Tick,
+		WatchPanics:       atomic.LoadInt64(&server.WatchPanics),
 	}
 }
 
@@ -444,27 +446,38 @@ func (server *Server) watch(sc storage.StorageChan) {
 			// Channel closed
 			break
 		}
-		if ev.Key != "" {
-			server.Console.Log("broadcast[" + ev.Key + "]")
-			server.Stream.Broadcast(ev.Key, stream.BroadcastOpt{
-				Key:       ev.Key,
-				Operation: ev.Operation,
-				Object:    ev.Object,
-				FilterObject: func(key string, obj meta.Object) (meta.Object, error) {
-					return server.filters.ReadObject.CheckWithListFallback(key, obj, server.Static, server.filters.ReadList)
-				},
-				FilterList: func(key string, objs []meta.Object) ([]meta.Object, error) {
-					return server.filters.ReadList.Check(key, objs, server.Static)
-				},
-				Static: server.Static,
-			})
-			if server.OnStorageEvent != nil {
-				server.OnStorageEvent(ev)
-			}
-		}
+		server.processEvent(ev)
 		if !server.Storage.Active() {
 			break
 		}
+	}
+}
+
+func (server *Server) processEvent(ev storage.Event) {
+	defer func() {
+		if r := recover(); r != nil {
+			atomic.AddInt64(&server.WatchPanics, 1)
+			server.Console.Err("watch:panic recovered, total:", atomic.LoadInt64(&server.WatchPanics), r)
+		}
+	}()
+	if ev.Key == "" {
+		return
+	}
+	server.Console.Log("broadcast[" + ev.Key + "]")
+	server.Stream.Broadcast(ev.Key, stream.BroadcastOpt{
+		Key:       ev.Key,
+		Operation: ev.Operation,
+		Object:    ev.Object,
+		FilterObject: func(key string, obj meta.Object) (meta.Object, error) {
+			return server.filters.ReadObject.CheckWithListFallback(key, obj, server.Static, server.filters.ReadList)
+		},
+		FilterList: func(key string, objs []meta.Object) ([]meta.Object, error) {
+			return server.filters.ReadList.Check(key, objs, server.Static)
+		},
+		Static: server.Static,
+	})
+	if server.OnStorageEvent != nil {
+		server.OnStorageEvent(ev)
 	}
 }
 

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -46,6 +46,7 @@ type ServerInfo struct {
 	Silence           bool          `json:"silence"`
 	Workers           int           `json:"workers"`
 	Tick              time.Duration `json:"tick"`
+	WatchPanics       int64         `json:"watchPanics"`
 }
 
 // FilterInfo contains detailed information about a filter path


### PR DESCRIPTION
## Changes

- **Panic recovery**: Added defer/recover in `processEvent()` called by `watch()` to prevent channel consumer death from killing the goroutine
- **Observability**: Added `WatchPanics` atomic counter to `Server` struct, exposed via `ServerInfo` API/UI
- **Dependency cleanup**: Updated jsonpatch and jsondiff to use `benitogf/go-json` fork, completely eliminating `goccy/go-json` from the dependency tree

## Root cause
`goccy/go-json` has a data race in its encoder/decoder compiler cache (#566). Under concurrent first-time decode, this can cause a panic in the `watch()` goroutine. Since `watch()` had no panic recovery, the channel consumer would die, the 100-event buffer would fill, and `Storage.Set()` would block forever.

All tests pass.