### PR TITLE
fix: add send timeout to prevent watch goroutine self-deadlock

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -3,6 +3,8 @@ package storage
 import (
 	"errors"
 	"hash/fnv"
+	"log"
+	"time"
 
 	"github.com/benitogf/go-json"
 
@@ -65,10 +67,28 @@ func NewShardedChan(shardCount int) *ShardedChan {
 	}
 }
 
-// Send routes an event to the appropriate shard based on key hash.
-func (s *ShardedChan) Send(event Event) {
+// SEND_TIMEOUT is the maximum time to wait when sending an event to a shard channel.
+// If the consumer goroutine is stuck or dead, the send will time out and the event
+// will be dropped with a log warning, preventing permanent write hangs.
+const SEND_TIMEOUT = 5 * time.Second
+
+// SendWithTimeout attempts to send an event to the appropriate shard channel
+// within the given timeout. Returns true if sent, false if timed out.
+func (s *ShardedChan) SendWithTimeout(event Event, timeout time.Duration) bool {
 	shard := s.ShardFor(event.Key)
-	s.shards[shard] <- event
+	select {
+	case s.shards[shard] <- event:
+		return true
+	case <-time.After(timeout):
+		log.Printf("storage: send timeout on shard %d for key %q (consumer stuck or dead), event dropped", shard, event.Key)
+		return false
+	}
+}
+
+// Send routes an event to the appropriate shard based on key hash.
+// Uses SEND_TIMEOUT to prevent permanent blocking if the shard consumer is stuck.
+func (s *ShardedChan) Send(event Event) {
+	s.SendWithTimeout(event, SEND_TIMEOUT)
 }
 
 // ShardFor returns the shard index for a given key using FNV-1a hash.

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -3,10 +3,11 @@ package storage
 import (
 	"sync"
 	"testing"
+	"time"
 
+	"github.com/benitogf/go-json"
 	"github.com/benitogf/ooo/meta"
 	"github.com/benitogf/ooo/monotonic"
-	"github.com/benitogf/go-json"
 	"github.com/stretchr/testify/require"
 )
 
@@ -616,4 +617,35 @@ func TestSetBeforeReadConcurrent(t *testing.T) {
 	mu.Lock()
 	require.LessOrEqual(t, callCount, 10)
 	mu.Unlock()
+}
+
+// TestSendTimeoutPreventsWatchSelfDeadlock verifies that Send with a timeout
+// prevents the watch goroutine from deadlocking when it writes back to storage
+// (e.g. version vector updates) while processing an event.
+//
+// The deadlock scenario:
+//  1. Watch goroutine for shard X receives an event
+//  2. During processing (OnStorageEvent), it writes to storage (VV increment)
+//  3. That write calls sendEvent(), which sends to a shard channel
+//  4. If that event hashes to shard X AND the buffer is full, the watch
+//     goroutine blocks trying to send to its own channel — self-deadlock
+//
+// Uses SendWithTimeout directly with a short timeout to keep the test fast.
+func TestSendTimeoutPreventsWatchSelfDeadlock(t *testing.T) {
+	t.Parallel()
+
+	sc := NewShardedChan(1) // single shard = guaranteed self-send
+	defer sc.Close()
+
+	// Fill the channel buffer completely (capacity 100)
+	for i := range 100 {
+		sc.Send(Event{Key: "fill/" + string(rune('a'+i%26)) + string(rune('0'+i/26))})
+	}
+
+	// Now simulate the self-deadlock: the watch goroutine (consumer of shard 0)
+	// tries to send to shard 0 while the buffer is full.
+	// Without timeout, this blocks forever.
+	// With timeout, it returns false.
+	ok := sc.SendWithTimeout(Event{Key: "self/deadlock"}, 1*time.Millisecond)
+	require.False(t, ok, "send to full channel should time out, not block forever")
 }


### PR DESCRIPTION
## Summary
- Add `SendWithTimeout()` to `ShardedChan` with configurable timeout
- `Send()` now uses `SEND_TIMEOUT` (5s) instead of blocking forever
- Add regression test that reproduces the self-deadlock in 1ms

## Root Cause

The `OnStorageEvent` callback (pivot sync) writes back to storage from inside the watch goroutine:

```
watch goroutine receives event "status/42" from shard X
  → processEvent
    → OnStorageEvent
      → Storage.Del("pivot/status")        ← sendEvent → shard channel
      → VVManager.Increment("status/42")
        → Storage.Set("pivot/vv/status")   ← sendEvent → shard channel
```

The watch goroutine is the **only consumer** of its shard channel. If either write-back event hashes to the same shard and the buffer (100) is full, the goroutine blocks trying to send to a channel only it can drain — **self-deadlock**.

This matches the production symptoms exactly:
- One device's writes hang forever (its shard is deadlocked)
- Other devices work (different shards)
- Reads unaffected (bypass event channel)
- No panic, no crash (channel block, not a panic)

## Test plan
- [x] `TestSendTimeoutPreventsWatchSelfDeadlock` — fills channel buffer, verifies `SendWithTimeout` returns false instead of blocking
- [x] All 24 storage tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)