### PR TITLE
fix(storage): serialize layered mutators with per-key locking

### DIFF
--- a/storage/layered.go
+++ b/storage/layered.go
@@ -216,9 +216,14 @@ func (l *Layered) SetAndUnlock(path string, data json.RawMessage) (string, error
 	if err != nil {
 		return "", err
 	}
-	res, err := l.Set(path, data)
-	lock.Unlock()
-	return res, err
+	defer lock.Unlock()
+	if !key.IsValid(path) {
+		return path, ErrInvalidPath
+	}
+	if len(data) == 0 {
+		return path, ErrInvalidStorageData
+	}
+	return l.setLocked(path, data), nil
 }
 
 // Unlock unlocks a key mutex
@@ -421,6 +426,16 @@ func (l *Layered) Set(path string, data json.RawMessage) (string, error) {
 		return path, ErrGlobNotAllowed
 	}
 
+	lock := l._getLock(path)
+	lock.Lock()
+	defer lock.Unlock()
+	return l.setLocked(path, data), nil
+}
+
+// setLocked writes to all layers and broadcasts. Caller must hold _getLock(path).
+// Without this serialization, concurrent writers can interleave layer writes
+// (memory ends up at writer A, embedded at writer B), breaking the mirror invariant.
+func (l *Layered) setLocked(path string, data json.RawMessage) string {
 	now := monotonic.Now()
 	index := key.LastIndex(path)
 	created, updated := l.peek(path, now)
@@ -433,7 +448,6 @@ func (l *Layered) Set(path string, data json.RawMessage) (string, error) {
 		Data:    data,
 	}
 
-	// Write to all layers
 	if l.memory != nil {
 		_ = l.memory.Set(path, obj)
 	}
@@ -448,7 +462,7 @@ func (l *Layered) Set(path string, data json.RawMessage) (string, error) {
 		l.afterWrite(path)
 	}
 
-	return index, nil
+	return index
 }
 
 // Push stores data under a new key generated from a glob pattern path
@@ -475,7 +489,10 @@ func (l *Layered) Push(path string, data json.RawMessage) (string, error) {
 		Data:    data,
 	}
 
-	// Write to all layers
+	lock := l._getLock(newPath)
+	lock.Lock()
+	defer lock.Unlock()
+
 	if l.memory != nil {
 		_ = l.memory.Set(newPath, obj)
 	}
@@ -508,7 +525,10 @@ func (l *Layered) SetWithMeta(path string, data json.RawMessage, created, update
 		Data:    data,
 	}
 
-	// Write to all layers
+	lock := l._getLock(path)
+	lock.Lock()
+	defer lock.Unlock()
+
 	if l.memory != nil {
 		_ = l.memory.Set(path, obj)
 	}
@@ -528,18 +548,20 @@ func (l *Layered) SetWithMeta(path string, data json.RawMessage, created, update
 
 // Del deletes a key from all layers
 func (l *Layered) Del(path string) error {
-	var obj *meta.Object
-
-	// Get object for broadcast before deleting
-	if !key.HasGlob(path) {
-		o, err := l.Get(path)
-		if err != nil {
-			return ErrNotFound
-		}
-		obj = &o
+	if key.HasGlob(path) {
+		return l.delGlob(path)
 	}
 
-	// Delete from all layers
+	lock := l._getLock(path)
+	lock.Lock()
+	defer lock.Unlock()
+
+	o, err := l.Get(path)
+	if err != nil {
+		return ErrNotFound
+	}
+	obj := &o
+
 	if l.memory != nil {
 		_ = l.memory.Del(path)
 	}
@@ -557,17 +579,47 @@ func (l *Layered) Del(path string) error {
 	return nil
 }
 
-// DelSilent deletes a key from all layers without broadcasting
-func (l *Layered) DelSilent(path string) error {
-	// Check existence for non-glob paths
-	if !key.HasGlob(path) {
-		_, err := l.Get(path)
-		if err != nil {
-			return ErrNotFound
-		}
+// delGlob deletes all keys matching a glob pattern across all layers.
+// Per-key locking is not applied because the glob doesn't resolve to a single
+// key; the underlying layers handle their own internal locking for glob deletes.
+func (l *Layered) delGlob(path string) error {
+	if l.memory != nil {
+		_ = l.memory.Del(path)
+	}
+	if l.embedded != nil {
+		_ = l.embedded.Del(path)
 	}
 
-	// Delete from all layers
+	if !key.Contains(l.noBroadcastKeys, path) && l.Active() {
+		l.sendEvent(Event{Key: path, Operation: "del", Object: nil})
+	}
+	if l.afterWrite != nil {
+		l.afterWrite(path)
+	}
+
+	return nil
+}
+
+// DelSilent deletes a key from all layers without broadcasting
+func (l *Layered) DelSilent(path string) error {
+	if key.HasGlob(path) {
+		if l.memory != nil {
+			_ = l.memory.Del(path)
+		}
+		if l.embedded != nil {
+			_ = l.embedded.Del(path)
+		}
+		return nil
+	}
+
+	lock := l._getLock(path)
+	lock.Lock()
+	defer lock.Unlock()
+
+	if _, err := l.Get(path); err != nil {
+		return ErrNotFound
+	}
+
 	if l.memory != nil {
 		_ = l.memory.Del(path)
 	}

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -607,3 +607,111 @@ func TestSendTimeoutPreventsWatchSelfDeadlock(t *testing.T) {
 	ok := sc.SendWithTimeout(Event{Key: "self/deadlock"}, 1*time.Millisecond)
 	require.False(t, ok, "send to full channel should time out, not block forever")
 }
+
+// holdingEmbeddedLayer wraps a MemoryLayer and pauses the first Set call to
+// holdKey until release is closed, signalling blocked once that Set has parked.
+// Used to deterministically interleave two concurrent writers across the
+// memory→embedded boundary.
+type holdingEmbeddedLayer struct {
+	inner   *MemoryLayer
+	holdKey string
+	blocked chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (h *holdingEmbeddedLayer) Active() bool               { return h.inner.Active() }
+func (h *holdingEmbeddedLayer) Start(o LayerOptions) error { return h.inner.Start(o) }
+func (h *holdingEmbeddedLayer) Close()                     { h.inner.Close() }
+func (h *holdingEmbeddedLayer) Get(k string) (meta.Object, error) {
+	return h.inner.Get(k)
+}
+func (h *holdingEmbeddedLayer) GetList(p string) ([]meta.Object, error) {
+	return h.inner.GetList(p)
+}
+func (h *holdingEmbeddedLayer) Set(k string, o *meta.Object) error {
+	if k == h.holdKey {
+		first := false
+		h.once.Do(func() { first = true })
+		if first {
+			close(h.blocked)
+			<-h.release
+		}
+	}
+	return h.inner.Set(k, o)
+}
+func (h *holdingEmbeddedLayer) Del(k string) error      { return h.inner.Del(k) }
+func (h *holdingEmbeddedLayer) Keys() ([]string, error) { return h.inner.Keys() }
+func (h *holdingEmbeddedLayer) Clear()                  { h.inner.Clear() }
+func (h *holdingEmbeddedLayer) Load() (map[string]*meta.Object, error) {
+	keys, err := h.inner.Keys()
+	if err != nil {
+		return nil, err
+	}
+	data := make(map[string]*meta.Object, len(keys))
+	for _, k := range keys {
+		obj, err := h.inner.Get(k)
+		if err != nil {
+			continue
+		}
+		data[k] = &obj
+	}
+	return data, nil
+}
+
+// TestLayeredConcurrentSetMirrorInvariant drives two concurrent Set calls to
+// the same key with the embedded layer artificially paused mid-write. Without
+// per-key serialization across both layers, writer B can complete entirely
+// while writer A is mid-write, leaving memory and embedded with different
+// values — breaking the invariant that memory mirrors embedded.
+func TestLayeredConcurrentSetMirrorInvariant(t *testing.T) {
+	embedded := &holdingEmbeddedLayer{
+		inner:   NewMemoryLayer(),
+		holdKey: "k",
+		blocked: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	memory := NewMemoryLayer()
+	s := New(LayeredConfig{Memory: memory, Embedded: embedded})
+	require.NoError(t, s.Start(Options{}))
+	defer s.Close()
+
+	aDone := make(chan error, 1)
+	go func() {
+		_, err := s.Set("k", json.RawMessage(`"A"`))
+		aDone <- err
+	}()
+
+	select {
+	case <-embedded.blocked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("writer A never reached embedded.Set")
+	}
+
+	bDone := make(chan error, 1)
+	go func() {
+		_, err := s.Set("k", json.RawMessage(`"B"`))
+		bDone <- err
+	}()
+
+	bFinishedFirst := false
+	select {
+	case err := <-bDone:
+		require.NoError(t, err)
+		bFinishedFirst = true
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	close(embedded.release)
+	require.NoError(t, <-aDone)
+	if !bFinishedFirst {
+		require.NoError(t, <-bDone)
+	}
+
+	memObj, err := memory.Get("k")
+	require.NoError(t, err)
+	embObj, err := embedded.inner.Get("k")
+	require.NoError(t, err)
+	require.Equal(t, string(memObj.Data), string(embObj.Data),
+		"mirror invariant violated: memory=%s embedded=%s", string(memObj.Data), string(embObj.Data))
+}


### PR DESCRIPTION
## Summary
Closes #41 — concurrent writers updating the same key no longer leave in-memory and on-disk state disagreeing.

- Two writers racing on the same key now land on the same value in both copies.
- On restart, the in-memory rebuild from disk no longer silently rolls back recent state.
- Held-lock callers (get-and-lock followed by set-and-unlock) keep working unchanged.
- Glob deletes are unchanged in behavior.

## Test plan
- [ ] New test drives two concurrent writes to the same key with the lower layer paused mid-write; memory and disk agree at the end.
- [ ] The new test fails on `main` and passes on this branch.
- [ ] Existing get-and-lock / set-and-unlock test still passes.
- [ ] Full test suite passes under the race detector.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)