### PR TITLE
fix: pivot prefix match requires segment boundary

### DIFF
--- a/ooo.go
+++ b/ooo.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -192,9 +193,11 @@ func (server *Server) getServerInfo() ui.ServerInfo {
 // pivotPrefix is the prefix used for internal pivot synchronization keys
 const pivotPrefix = "pivot"
 
-// isPivotPath checks if a path is a pivot internal path
+// isPivotPath checks if a path is a pivot internal path.
+// A path is internal only when it equals the bare prefix or sits under it
+// as a path segment (pivot/...); a user key like "pivothings" is not.
 func isPivotPath(path string) bool {
-	return len(path) >= len(pivotPrefix) && path[:len(pivotPrefix)] == pivotPrefix
+	return path == pivotPrefix || strings.HasPrefix(path, pivotPrefix+"/")
 }
 
 // limitFilterReg stores a limit filter registration for lazy evaluation

--- a/ooo_test.go
+++ b/ooo_test.go
@@ -171,3 +171,35 @@ func TestOnStartComposition(t *testing.T) {
 
 	require.Equal(t, []string{"first", "second"}, order)
 }
+
+func TestIsPivotPath(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		path string
+		want bool
+	}{
+		// real pivot internal paths
+		{"pivot", true},
+		{"pivot/", true},
+		{"pivot/status", true},
+		{"pivot/sync/node-1", true},
+
+		// user keys that merely start with the letters "pivot"
+		{"pivothings", false},
+		{"pivots", false},
+		{"pivots/x", false},
+		{"pivotal", false},
+
+		// unrelated keys
+		{"", false},
+		{"piv", false},
+		{"things/pivot", false},
+		{"users/alice", false},
+	}
+
+	for _, c := range cases {
+		require.Equalf(t, c.want, isPivotPath(c.path),
+			"isPivotPath(%q) = %v, want %v", c.path, !c.want, c.want)
+	}
+}


### PR DESCRIPTION
## Summary
Closes #43 — user keys whose names happen to start with the five letters "pivot" are no longer mistaken for internal pivot synchronization keys.

- The explorer's orphan-keys list now shows user keys like "pivothings", "pivots/x", "pivotal".
- The filter-info list likewise stops hiding filters whose paths happen to begin with those letters.
- Real pivot-internal paths ("pivot", "pivot/status", "pivot/sync/...") continue to be filtered as before.

## Test plan
- [ ] New unit test covers both the user-key cases (must be visible) and the real pivot-internal cases (must remain hidden).
- [ ] The new test fails on `main` and passes on this branch.
- [ ] Full test suite passes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)