### PR TITLE
feat: surface offending event on watch-goroutine panic

### DIFF
--- a/ooo.go
+++ b/ooo.go
@@ -147,6 +147,7 @@ type Server struct {
 	ReadHeaderTimeout  time.Duration
 	IdleTimeout        time.Duration
 	OnStorageEvent     storage.EventCallback
+	OnWatchPanic       func(ev storage.Event, r any) // optional: invoked on each recovered watch-goroutine panic with the offending event
 	BeforeRead         func(key string)
 	GetPivotInfo       func() *ui.PivotInfo // Optional: returns pivot status for UI
 	NoCompress         bool                 // Disable gzip compression (useful for tests)
@@ -460,7 +461,11 @@ func (server *Server) processEvent(ev storage.Event) {
 	defer func() {
 		if r := recover(); r != nil {
 			atomic.AddInt64(&server.WatchPanics, 1)
-			server.Console.Err("watch:panic recovered, total:", atomic.LoadInt64(&server.WatchPanics), r)
+			server.Console.Err(fmt.Sprintf("watch:panic recovered key=%q op=%q total=%d: %v",
+				ev.Key, ev.Operation, atomic.LoadInt64(&server.WatchPanics), r))
+			if server.OnWatchPanic != nil {
+				server.OnWatchPanic(ev, r)
+			}
 		}
 	}()
 	if ev.Key == "" {

--- a/ooo_test.go
+++ b/ooo_test.go
@@ -5,9 +5,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/benitogf/go-json"
+	"github.com/benitogf/ooo/storage"
 	"github.com/stretchr/testify/require"
 )
 
@@ -202,4 +205,43 @@ func TestIsPivotPath(t *testing.T) {
 		require.Equalf(t, c.want, isPivotPath(c.path),
 			"isPivotPath(%q) = %v, want %v", c.path, !c.want, c.want)
 	}
+}
+
+func TestOnWatchPanicReceivesOffendingEvent(t *testing.T) {
+	type capture struct {
+		ev storage.Event
+		r  any
+	}
+	got := make(chan capture, 1)
+
+	server := &Server{
+		Silence: true,
+		Workers: 1,
+	}
+	server.OnStorageEvent = func(ev storage.Event) {
+		panic("boom")
+	}
+	server.OnWatchPanic = func(ev storage.Event, r any) {
+		select {
+		case got <- capture{ev: ev, r: r}:
+		default:
+		}
+	}
+
+	server.Start("localhost:0")
+	defer server.Close(os.Interrupt)
+
+	_, err := server.Storage.Set("test/key", json.RawMessage(`{"v":1}`))
+	require.NoError(t, err)
+
+	select {
+	case c := <-got:
+		require.Equal(t, "test/key", c.ev.Key)
+		require.Equal(t, "set", c.ev.Operation)
+		require.NotNil(t, c.r)
+	case <-time.After(2 * time.Second):
+		t.Fatal("OnWatchPanic was not invoked")
+	}
+
+	require.Equal(t, int64(1), atomic.LoadInt64(&server.WatchPanics))
 }


### PR DESCRIPTION
## Summary
Closes #47 — a recovered watch-goroutine panic now identifies which event triggered it and notifies the application.

- The recovery log line now includes the offending key and operation, so operators can tell *what* failed instead of just *that something* failed.
- A new optional callback on the server fires on each recovered panic with the original event and the panic value, letting applications wire their own alerting (metrics, paging, structured logs) without polling the global counter.
- The existing panic counter still increments unchanged.

## Test plan
- [ ] New test drives a panicking event handler and asserts the callback fires with the right key, operation, and panic value.
- [ ] The new test fails on `main` (callback does not exist) and passes on this branch.
- [ ] The existing panic-counter behavior continues to work.
- [ ] Full test suite passes under `-race`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)