### PR TITLE
fix(client): respect context cancel and retry config on dial failure

### DIFF
--- a/client/subscribe.go
+++ b/client/subscribe.go
@@ -10,10 +10,10 @@ import (
 	"time"
 
 	"github.com/benitogf/coat"
+	"github.com/benitogf/go-json"
 	"github.com/benitogf/ooo/key"
 	"github.com/benitogf/ooo/messages"
 	"github.com/benitogf/ooo/meta"
-	"github.com/benitogf/go-json"
 	"github.com/gorilla/websocket"
 )
 
@@ -166,6 +166,7 @@ func (s *subscribeState[T]) logPrefix() string {
 
 // connect establishes a WebSocket connection.
 // Returns true if connection was successful, false otherwise.
+// Backoff on failure is the caller's responsibility (see waitRetry).
 func (s *subscribeState[T]) connect() bool {
 	dialer := &websocket.Dialer{
 		Proxy:            http.ProxyFromEnvironment,
@@ -174,14 +175,13 @@ func (s *subscribeState[T]) connect() bool {
 
 	s.muClient.Lock()
 	var err error
-	s.wsClient, _, err = dialer.Dial(s.wsURL.String(), s.cfg.Header)
+	s.wsClient, _, err = dialer.DialContext(s.cfg.Ctx, s.wsURL.String(), s.cfg.Header)
 	if s.wsClient == nil || err != nil {
 		s.muClient.Unlock()
 		s.cfg.console.Err(s.logPrefix()+": failed websocket dial", err)
 		if s.events.OnError != nil {
 			s.events.OnError(err)
 		}
-		time.Sleep(2 * time.Second)
 		return false
 	}
 	s.muClient.Unlock()
@@ -243,20 +243,25 @@ func (s *subscribeState[T]) readLoop() {
 }
 
 // waitRetry waits before reconnecting based on retry count.
+// Returns immediately if the subscription context is cancelled.
 func (s *subscribeState[T]) waitRetry() {
 	s.retryCount++
-	if s.retryCount < s.cfg.Retry.MediumThreshold {
+	var delay time.Duration
+	switch {
+	case s.retryCount < s.cfg.Retry.MediumThreshold:
 		s.cfg.console.Log(s.logPrefix() + ": reconnecting...")
-		time.Sleep(s.cfg.Retry.InitialDelay)
-		return
-	}
-	if s.retryCount < s.cfg.Retry.MaxThreshold {
+		delay = s.cfg.Retry.InitialDelay
+	case s.retryCount < s.cfg.Retry.MaxThreshold:
 		s.cfg.console.Log(s.logPrefix()+": reconnecting in", s.cfg.Retry.MediumDelay)
-		time.Sleep(s.cfg.Retry.MediumDelay)
-		return
+		delay = s.cfg.Retry.MediumDelay
+	default:
+		s.cfg.console.Log(s.logPrefix()+": reconnecting in", s.cfg.Retry.MaxDelay)
+		delay = s.cfg.Retry.MaxDelay
 	}
-	s.cfg.console.Log(s.logPrefix()+": reconnecting in", s.cfg.Retry.MaxDelay)
-	time.Sleep(s.cfg.Retry.MaxDelay)
+	select {
+	case <-time.After(delay):
+	case <-s.cfg.Ctx.Done():
+	}
 }
 
 // startCloseWatcher starts a goroutine that closes the connection when context is done.
@@ -311,6 +316,7 @@ func Subscribe[T any](cfg SubscribeConfig, path string, events SubscribeEvents[T
 		}
 
 		if !state.connect() {
+			state.waitRetry()
 			continue
 		}
 
@@ -346,6 +352,7 @@ func (s *subscribeListState[T]) logPrefix() string {
 
 // connect establishes a WebSocket connection.
 // Returns true if connection was successful, false otherwise.
+// Backoff on failure is the caller's responsibility (see waitRetry).
 func (s *subscribeListState[T]) connect() bool {
 	dialer := &websocket.Dialer{
 		Proxy:            http.ProxyFromEnvironment,
@@ -354,14 +361,13 @@ func (s *subscribeListState[T]) connect() bool {
 
 	s.muClient.Lock()
 	var err error
-	s.wsClient, _, err = dialer.Dial(s.wsURL.String(), s.cfg.Header)
+	s.wsClient, _, err = dialer.DialContext(s.cfg.Ctx, s.wsURL.String(), s.cfg.Header)
 	if s.wsClient == nil || err != nil {
 		s.muClient.Unlock()
 		s.cfg.console.Err(s.logPrefix()+": failed websocket dial", err)
 		if s.events.OnError != nil {
 			s.events.OnError(err)
 		}
-		time.Sleep(2 * time.Second)
 		return false
 	}
 	s.muClient.Unlock()
@@ -428,20 +434,25 @@ func (s *subscribeListState[T]) readLoop() {
 }
 
 // waitRetry waits before reconnecting based on retry count.
+// Returns immediately if the subscription context is cancelled.
 func (s *subscribeListState[T]) waitRetry() {
 	s.retryCount++
-	if s.retryCount < s.cfg.Retry.MediumThreshold {
+	var delay time.Duration
+	switch {
+	case s.retryCount < s.cfg.Retry.MediumThreshold:
 		s.cfg.console.Log(s.logPrefix() + ": reconnecting...")
-		time.Sleep(s.cfg.Retry.InitialDelay)
-		return
-	}
-	if s.retryCount < s.cfg.Retry.MaxThreshold {
+		delay = s.cfg.Retry.InitialDelay
+	case s.retryCount < s.cfg.Retry.MaxThreshold:
 		s.cfg.console.Log(s.logPrefix()+": reconnecting in", s.cfg.Retry.MediumDelay)
-		time.Sleep(s.cfg.Retry.MediumDelay)
-		return
+		delay = s.cfg.Retry.MediumDelay
+	default:
+		s.cfg.console.Log(s.logPrefix()+": reconnecting in", s.cfg.Retry.MaxDelay)
+		delay = s.cfg.Retry.MaxDelay
 	}
-	s.cfg.console.Log(s.logPrefix()+": reconnecting in", s.cfg.Retry.MaxDelay)
-	time.Sleep(s.cfg.Retry.MaxDelay)
+	select {
+	case <-time.After(delay):
+	case <-s.cfg.Ctx.Done():
+	}
 }
 
 // startCloseWatcher starts a goroutine that closes the connection when context is done.
@@ -496,6 +507,7 @@ func SubscribeList[T any](cfg SubscribeConfig, path string, events SubscribeList
 		}
 
 		if !state.connect() {
+			state.waitRetry()
 			continue
 		}
 

--- a/client/subscribe_test.go
+++ b/client/subscribe_test.go
@@ -134,8 +134,8 @@ func TestClientCloseWhileReconnecting(t *testing.T) {
 func TestClientCloseWithoutConnection(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	var connectionFailed sync.WaitGroup
-	connectionFailed.Add(1)
+	var connectionFailedOnce sync.Once
+	connectionFailed := make(chan struct{})
 	var exited sync.WaitGroup
 	exited.Add(1)
 	messageReceived := false
@@ -152,12 +152,12 @@ func TestClientCloseWithoutConnection(t *testing.T) {
 				messageReceived = true
 			},
 			OnError: func(err error) {
-				connectionFailed.Done()
+				connectionFailedOnce.Do(func() { close(connectionFailed) })
 			},
 		})
 	}()
 
-	connectionFailed.Wait()
+	<-connectionFailed
 	cancel()
 	exited.Wait()
 	require.False(t, messageReceived, "OnMessage should not be called when connection fails")
@@ -201,4 +201,50 @@ func TestClientListCallbackCurry(t *testing.T) {
 	}
 
 	require.Equal(t, NUM_DEVICES+1, messagesCount)
+}
+
+// TestSubscribeCancelExitsPromptlyOnDialFailure asserts that cancelling the
+// subscription context during a dial-failure backoff propagates within
+// hundreds of milliseconds. Before the fix, the dial-failure path slept a
+// fixed two seconds with no context awareness, so cancellation was delayed.
+func TestSubscribeCancelExitsPromptlyOnDialFailure(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	gotErr := make(chan struct{}, 1)
+	exited := make(chan struct{})
+	go func() {
+		defer close(exited)
+		_ = client.SubscribeList(client.SubscribeConfig{
+			Ctx:              ctx,
+			Server:           client.Server{Protocol: "ws", Host: "127.0.0.1:1"},
+			HandshakeTimeout: 10 * time.Millisecond,
+			Silence:          true,
+		}, "devices/*", client.SubscribeListEvents[Device]{
+			OnMessage: func([]client.Meta[Device]) {},
+			OnError: func(error) {
+				select {
+				case gotErr <- struct{}{}:
+				default:
+				}
+			},
+		})
+	}()
+
+	select {
+	case <-gotErr:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first dial failure was never reported")
+	}
+
+	cancelAt := time.Now()
+	cancel()
+
+	select {
+	case <-exited:
+		require.Less(t, time.Since(cancelAt), 500*time.Millisecond,
+			"Subscribe should exit within 500ms of context cancellation")
+	case <-time.After(2 * time.Second):
+		t.Fatal("Subscribe did not exit within 2s after context cancellation")
+	}
 }

--- a/client/subscribe_test.go
+++ b/client/subscribe_test.go
@@ -101,10 +101,12 @@ func TestClientCloseWhileReconnecting(t *testing.T) {
 	server.Start("localhost:0")
 	ctx, cancel := context.WithCancel(context.Background())
 
+	var connected sync.WaitGroup
+	connected.Add(1)
 	var connectedOnce sync.Once
-	connected := make(chan struct{})
+	var disconnected sync.WaitGroup
+	disconnected.Add(1)
 	var disconnectedOnce sync.Once
-	disconnected := make(chan struct{})
 	var exited sync.WaitGroup
 	exited.Add(1)
 
@@ -116,17 +118,17 @@ func TestClientCloseWhileReconnecting(t *testing.T) {
 			Silence: true,
 		}, "devices/*", client.SubscribeListEvents[Device]{
 			OnMessage: func(devices []client.Meta[Device]) {
-				connectedOnce.Do(func() { close(connected) })
+				connectedOnce.Do(connected.Done)
 			},
 			OnError: func(err error) {
-				disconnectedOnce.Do(func() { close(disconnected) })
+				disconnectedOnce.Do(disconnected.Done)
 			},
 		})
 	}()
 
-	<-connected
+	connected.Wait()
 	server.Close(os.Interrupt)
-	<-disconnected
+	disconnected.Wait()
 	cancel()
 	exited.Wait()
 }
@@ -134,8 +136,9 @@ func TestClientCloseWhileReconnecting(t *testing.T) {
 func TestClientCloseWithoutConnection(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
+	var connectionFailed sync.WaitGroup
+	connectionFailed.Add(1)
 	var connectionFailedOnce sync.Once
-	connectionFailed := make(chan struct{})
 	var exited sync.WaitGroup
 	exited.Add(1)
 	messageReceived := false
@@ -152,12 +155,12 @@ func TestClientCloseWithoutConnection(t *testing.T) {
 				messageReceived = true
 			},
 			OnError: func(err error) {
-				connectionFailedOnce.Do(func() { close(connectionFailed) })
+				connectionFailedOnce.Do(connectionFailed.Done)
 			},
 		})
 	}()
 
-	<-connectionFailed
+	connectionFailed.Wait()
 	cancel()
 	exited.Wait()
 	require.False(t, messageReceived, "OnMessage should not be called when connection fails")
@@ -211,10 +214,14 @@ func TestSubscribeCancelExitsPromptlyOnDialFailure(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	gotErr := make(chan struct{}, 1)
-	exited := make(chan struct{})
+	var firstErr sync.WaitGroup
+	firstErr.Add(1)
+	var firstErrOnce sync.Once
+	var exited sync.WaitGroup
+	exited.Add(1)
+
 	go func() {
-		defer close(exited)
+		defer exited.Done()
 		_ = client.SubscribeList(client.SubscribeConfig{
 			Ctx:              ctx,
 			Server:           client.Server{Protocol: "ws", Host: "127.0.0.1:1"},
@@ -223,28 +230,15 @@ func TestSubscribeCancelExitsPromptlyOnDialFailure(t *testing.T) {
 		}, "devices/*", client.SubscribeListEvents[Device]{
 			OnMessage: func([]client.Meta[Device]) {},
 			OnError: func(error) {
-				select {
-				case gotErr <- struct{}{}:
-				default:
-				}
+				firstErrOnce.Do(firstErr.Done)
 			},
 		})
 	}()
 
-	select {
-	case <-gotErr:
-	case <-time.After(2 * time.Second):
-		t.Fatal("first dial failure was never reported")
-	}
-
+	firstErr.Wait()
 	cancelAt := time.Now()
 	cancel()
-
-	select {
-	case <-exited:
-		require.Less(t, time.Since(cancelAt), 500*time.Millisecond,
-			"Subscribe should exit within 500ms of context cancellation")
-	case <-time.After(2 * time.Second):
-		t.Fatal("Subscribe did not exit within 2s after context cancellation")
-	}
+	exited.Wait()
+	require.Less(t, time.Since(cancelAt), 500*time.Millisecond,
+		"Subscribe should exit within 500ms of context cancellation")
 }

--- a/client/subscribe_test.go
+++ b/client/subscribe_test.go
@@ -101,10 +101,10 @@ func TestClientCloseWhileReconnecting(t *testing.T) {
 	server.Start("localhost:0")
 	ctx, cancel := context.WithCancel(context.Background())
 
-	var connected sync.WaitGroup
-	connected.Add(1)
-	var disconnected sync.WaitGroup
-	disconnected.Add(1)
+	var connectedOnce sync.Once
+	connected := make(chan struct{})
+	var disconnectedOnce sync.Once
+	disconnected := make(chan struct{})
 	var exited sync.WaitGroup
 	exited.Add(1)
 
@@ -116,17 +116,17 @@ func TestClientCloseWhileReconnecting(t *testing.T) {
 			Silence: true,
 		}, "devices/*", client.SubscribeListEvents[Device]{
 			OnMessage: func(devices []client.Meta[Device]) {
-				connected.Done()
+				connectedOnce.Do(func() { close(connected) })
 			},
 			OnError: func(err error) {
-				disconnected.Done()
+				disconnectedOnce.Do(func() { close(disconnected) })
 			},
 		})
 	}()
 
-	connected.Wait()
+	<-connected
 	server.Close(os.Interrupt)
-	disconnected.Wait()
+	<-disconnected
 	cancel()
 	exited.Wait()
 }


### PR DESCRIPTION
## Summary
Closes #49 — the client subscription respects context cancellation and the configured retry backoff on dial failures.

- Cancelling the subscription context during a dial-failure backoff now propagates within milliseconds instead of being delayed up to two seconds.
- The configured initial / medium / max retry delays and thresholds now drive reconnection cadence on dial failures (previously they were silently bypassed and every retry was a fixed two-second wait).
- The dial itself now respects the subscription context, so a dial cannot outlive a cancelled subscription.

## Test plan
- [ ] New test asserts cancellation latency is under 500ms on a dead-server subscribe; previously took ~2s.
- [ ] The new test fails on `main` and passes on this branch.
- [ ] Existing client tests continue to pass under `-race` (one was updated to remain robust under the now-faster retry loop).
- [ ] Full test suite passes under `-race`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)