### PR TITLE
fix(proxy): use double-digit indices for ten or more wildcards

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -426,9 +426,9 @@ func GlobToMuxPattern(pattern string) string {
 			varCount++
 			// Last wildcard gets .* to match anything including slashes
 			if i == len(parts)-1 {
-				parts[i] = "{path" + string(rune('0'+varCount)) + ":.*}"
+				parts[i] = "{path" + strconv.Itoa(varCount) + ":.*}"
 			} else {
-				parts[i] = "{path" + string(rune('0'+varCount)) + "}"
+				parts[i] = "{path" + strconv.Itoa(varCount) + "}"
 			}
 		}
 	}

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benitogf/go-json"
 	"github.com/benitogf/ooo"
 	"github.com/benitogf/ooo/client"
 	"github.com/benitogf/ooo/proxy"
-	"github.com/benitogf/go-json"
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/require"
 )
@@ -39,6 +39,11 @@ func TestGlobToMuxPattern(t *testing.T) {
 		{"middle glob", "devices/*/things", "devices/{path1}/things"},
 		{"multiple globs", "devices/*/things/*", "devices/{path1}/things/{path2:.*}"},
 		{"nested path no glob", "api/v1/users", "api/v1/users"},
+		{
+			"ten wildcards",
+			"a/*/b/*/c/*/d/*/e/*/f/*/g/*/h/*/i/*/j/*",
+			"a/{path1}/b/{path2}/c/{path3}/d/{path4}/e/{path5}/f/{path6}/g/{path7}/h/{path8}/i/{path9}/j/{path10:.*}",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
Closes #51 — proxy routes with ten or more wildcard segments now register a valid pattern and actually match incoming requests.

- Routes with one to nine wildcards continue to work exactly as before.
- Routes with ten or more wildcards register correctly instead of silently producing a malformed pattern that no request can match.
- No behavior change for the common single- or few-wildcard cases.

## Test plan
- [ ] Existing one-to-nine-wildcard test cases still pass unchanged.
- [ ] New ten-wildcard test case asserts the resulting pattern uses a double-digit index.
- [ ] The new case fails on `main` and passes on this branch.
- [ ] Full test suite passes under `-race`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)