### PR TITLE
docs(storage): document the memory-layer aliasing contract

### DIFF
--- a/storage/memory.go
+++ b/storage/memory.go
@@ -9,7 +9,16 @@ import (
 	"github.com/benitogf/ooo/meta"
 )
 
-// MemoryLayer is an in-memory storage layer
+// MemoryLayer is an in-memory storage layer.
+//
+// Aliasing contract: values are kept by reference. Set retains the caller's
+// *meta.Object pointer and the backing array of obj.Data; Get and GetList
+// return Data slices that alias the stored bytes. Callers must not mutate any
+// of these — including the input to Set after the call returns, the Data
+// slice on a returned object, or the *meta.Object itself (e.g. via
+// meta.PutObject). For most use cases prefer the typed io.* helpers
+// (io.Get, io.Set, io.Push, io.Patch, io.GetList), which marshal /
+// unmarshal at the boundary and never expose the stored bytes to the caller.
 type MemoryLayer struct {
 	data   map[string]*meta.Object
 	mutex  sync.RWMutex
@@ -45,7 +54,10 @@ func (m *MemoryLayer) Close() {
 	m.active = false
 }
 
-// Get retrieves a single value by exact key
+// Get retrieves a single value by exact key.
+//
+// The returned Data slice aliases the stored bytes. Callers must not mutate
+// it. Prefer io.Get, which unmarshals into a typed value.
 func (m *MemoryLayer) Get(k string) (meta.Object, error) {
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
@@ -58,7 +70,10 @@ func (m *MemoryLayer) Get(k string) (meta.Object, error) {
 	return *obj, nil
 }
 
-// GetList retrieves all values matching a glob pattern
+// GetList retrieves all values matching a glob pattern.
+//
+// Each returned Data slice aliases the stored bytes. Callers must not mutate
+// any of them. Prefer io.GetList, which unmarshals into a typed slice.
 func (m *MemoryLayer) GetList(path string) ([]meta.Object, error) {
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
@@ -78,7 +93,14 @@ func (m *MemoryLayer) GetList(path string) ([]meta.Object, error) {
 	return res, nil
 }
 
-// Set stores a value
+// Set stores a value.
+//
+// The stored map keeps the caller's *meta.Object pointer and the backing
+// array of obj.Data. Callers must not mutate the input slice after this call,
+// reuse a buffer they passed in, or return the *meta.Object to a sync.Pool
+// (e.g. meta.PutObject) — any of those silently corrupt the store. Prefer
+// io.Set / io.Push / io.Patch, which marshal a typed value into a fresh
+// buffer that the caller never holds.
 func (m *MemoryLayer) Set(k string, obj *meta.Object) error {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()


### PR DESCRIPTION
## Summary
Closes #53 by documenting the memory-layer aliasing contract instead of paying to defend against it at runtime.

## Why this changed shape mid-PR
The original commit cloned the object and its `Data` slice on `Set`, `Get`, and `GetList` so the store and caller buffers were fully independent. Benchmarks against realistic payload sizes showed the cost was steep on the hot read path:

| Operation | Payload | Before (main) | With clones | Δ |
|---|---|---|---|---|
| `Get` | 100 B | 37 ns | 104 ns | +180% |
| `Get` | 1 KB | 47 ns | 317 ns | +570% |
| `Get` | 10 KB | 39 ns | 2.7 µs | ~70× |
| `GetList(20)` | 10 KB | 1.1 µs | 43 µs | ~40× |

Direct callers of `Storage.Set` / `Get` / `GetList` are being phased out in favour of the typed `io.*` helpers, which sidestep aliasing by construction (`json.Marshal` / `json.Unmarshal` copy at the boundary, so the stored bytes never escape):

- `io.Set` / `io.Push` / `io.Patch`: marshal a typed value into a fresh buffer; nobody else holds those bytes.
- `io.Get` / `io.GetList`: unmarshal into a typed `T`; the returned `client.Meta[T]` carries the typed value, not raw `Data`.
- `io.Patch` additionally feeds the merge through `merge.MergeBytes`, which is non-mutating on its inputs.

For an internal-network deployment with controlled callers, paying ~70× on Get to defend a path with no current at-risk caller wasn't worth it.

## What this PR does instead
- Documents the aliasing contract on `MemoryLayer`, `MemoryLayer.Set`, `MemoryLayer.Get`, `MemoryLayer.GetList` so a future reader sees the constraint and the recommended path.
- Names the io.\* helpers as the preferred API for new callers.
- No behavior change; no perf change.

## Test plan
- [ ] Full test suite passes under `-race`.
- [ ] No new tests — there is no behavior change. The earlier isolation tests have been removed since they would assert a contract this PR explicitly declines to enforce.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)