### PR TITLE
fix(storage): propagate embedded-layer write errors and skip broadcast

### DIFF
--- a/storage/layered.go
+++ b/storage/layered.go
@@ -223,7 +223,7 @@ func (l *Layered) SetAndUnlock(path string, data json.RawMessage) (string, error
 	if len(data) == 0 {
 		return path, ErrInvalidStorageData
 	}
-	return l.setLocked(path, data), nil
+	return l.setLocked(path, data)
 }
 
 // Unlock unlocks a key mutex
@@ -429,13 +429,20 @@ func (l *Layered) Set(path string, data json.RawMessage) (string, error) {
 	lock := l._getLock(path)
 	lock.Lock()
 	defer lock.Unlock()
-	return l.setLocked(path, data), nil
+	return l.setLocked(path, data)
 }
 
 // setLocked writes to all layers and broadcasts. Caller must hold _getLock(path).
 // Without this serialization, concurrent writers can interleave layer writes
-// (memory ends up at writer A, embedded at writer B), breaking the mirror invariant.
-func (l *Layered) setLocked(path string, data json.RawMessage) string {
+// (memory ends up at writer A, embedded at writer B), breaking the mirror
+// invariant.
+//
+// If the embedded layer rejects the write, the error is returned to the
+// caller and the broadcast / afterWrite hooks are suppressed: callers and
+// subscribers must not be told a write succeeded when it did not durably
+// commit. The memory layer keeps the new value (Layered is memory-first by
+// design); on restart embedded reseeds memory from the prior committed value.
+func (l *Layered) setLocked(path string, data json.RawMessage) (string, error) {
 	now := monotonic.Now()
 	index := key.LastIndex(path)
 	created, updated := l.peek(path, now)
@@ -449,10 +456,14 @@ func (l *Layered) setLocked(path string, data json.RawMessage) string {
 	}
 
 	if l.memory != nil {
-		_ = l.memory.Set(path, obj)
+		if err := l.memory.Set(path, obj); err != nil {
+			return index, err
+		}
 	}
 	if l.embedded != nil {
-		_ = l.embedded.Set(path, obj)
+		if err := l.embedded.Set(path, obj); err != nil {
+			return index, err
+		}
 	}
 
 	if !key.Contains(l.noBroadcastKeys, path) && l.Active() {
@@ -462,7 +473,7 @@ func (l *Layered) setLocked(path string, data json.RawMessage) string {
 		l.afterWrite(path)
 	}
 
-	return index
+	return index, nil
 }
 
 // Push stores data under a new key generated from a glob pattern path
@@ -494,10 +505,14 @@ func (l *Layered) Push(path string, data json.RawMessage) (string, error) {
 	defer lock.Unlock()
 
 	if l.memory != nil {
-		_ = l.memory.Set(newPath, obj)
+		if err := l.memory.Set(newPath, obj); err != nil {
+			return index, err
+		}
 	}
 	if l.embedded != nil {
-		_ = l.embedded.Set(newPath, obj)
+		if err := l.embedded.Set(newPath, obj); err != nil {
+			return index, err
+		}
 	}
 
 	if !key.Contains(l.noBroadcastKeys, newPath) && l.Active() {
@@ -530,10 +545,14 @@ func (l *Layered) SetWithMeta(path string, data json.RawMessage, created, update
 	defer lock.Unlock()
 
 	if l.memory != nil {
-		_ = l.memory.Set(path, obj)
+		if err := l.memory.Set(path, obj); err != nil {
+			return index, err
+		}
 	}
 	if l.embedded != nil {
-		_ = l.embedded.Set(path, obj)
+		if err := l.embedded.Set(path, obj); err != nil {
+			return index, err
+		}
 	}
 
 	if !key.Contains(l.noBroadcastKeys, path) && l.Active() {
@@ -563,10 +582,14 @@ func (l *Layered) Del(path string) error {
 	obj := &o
 
 	if l.memory != nil {
-		_ = l.memory.Del(path)
+		if err := l.memory.Del(path); err != nil {
+			return err
+		}
 	}
 	if l.embedded != nil {
-		_ = l.embedded.Del(path)
+		if err := l.embedded.Del(path); err != nil {
+			return err
+		}
 	}
 
 	if !key.Contains(l.noBroadcastKeys, path) && l.Active() {
@@ -584,10 +607,14 @@ func (l *Layered) Del(path string) error {
 // key; the underlying layers handle their own internal locking for glob deletes.
 func (l *Layered) delGlob(path string) error {
 	if l.memory != nil {
-		_ = l.memory.Del(path)
+		if err := l.memory.Del(path); err != nil {
+			return err
+		}
 	}
 	if l.embedded != nil {
-		_ = l.embedded.Del(path)
+		if err := l.embedded.Del(path); err != nil {
+			return err
+		}
 	}
 
 	if !key.Contains(l.noBroadcastKeys, path) && l.Active() {
@@ -604,10 +631,14 @@ func (l *Layered) delGlob(path string) error {
 func (l *Layered) DelSilent(path string) error {
 	if key.HasGlob(path) {
 		if l.memory != nil {
-			_ = l.memory.Del(path)
+			if err := l.memory.Del(path); err != nil {
+				return err
+			}
 		}
 		if l.embedded != nil {
-			_ = l.embedded.Del(path)
+			if err := l.embedded.Del(path); err != nil {
+				return err
+			}
 		}
 		return nil
 	}
@@ -621,10 +652,14 @@ func (l *Layered) DelSilent(path string) error {
 	}
 
 	if l.memory != nil {
-		_ = l.memory.Del(path)
+		if err := l.memory.Del(path); err != nil {
+			return err
+		}
 	}
 	if l.embedded != nil {
-		_ = l.embedded.Del(path)
+		if err := l.embedded.Del(path); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -748,4 +749,116 @@ func TestLayeredCloseRaceWithBroadcast(t *testing.T) {
 	time.Sleep(2 * time.Millisecond) // let writers reach the broadcast path
 	s.Close()
 	wg.Wait()
+}
+
+// faultyEmbeddedLayer wraps a MemoryLayer but returns the configured errors
+// from Set / Del so tests can simulate persistence failures.
+type faultyEmbeddedLayer struct {
+	inner  *MemoryLayer
+	setErr error
+	delErr error
+}
+
+func (f *faultyEmbeddedLayer) Active() bool                      { return f.inner.Active() }
+func (f *faultyEmbeddedLayer) Start(o LayerOptions) error        { return f.inner.Start(o) }
+func (f *faultyEmbeddedLayer) Close()                            { f.inner.Close() }
+func (f *faultyEmbeddedLayer) Get(k string) (meta.Object, error) { return f.inner.Get(k) }
+func (f *faultyEmbeddedLayer) GetList(p string) ([]meta.Object, error) {
+	return f.inner.GetList(p)
+}
+func (f *faultyEmbeddedLayer) Set(k string, o *meta.Object) error {
+	if f.setErr != nil {
+		return f.setErr
+	}
+	return f.inner.Set(k, o)
+}
+func (f *faultyEmbeddedLayer) Del(k string) error {
+	if f.delErr != nil {
+		return f.delErr
+	}
+	return f.inner.Del(k)
+}
+func (f *faultyEmbeddedLayer) Keys() ([]string, error) { return f.inner.Keys() }
+func (f *faultyEmbeddedLayer) Clear()                  { f.inner.Clear() }
+func (f *faultyEmbeddedLayer) Load() (map[string]*meta.Object, error) {
+	keys, err := f.inner.Keys()
+	if err != nil {
+		return nil, err
+	}
+	data := make(map[string]*meta.Object, len(keys))
+	for _, k := range keys {
+		obj, err := f.inner.Get(k)
+		if err != nil {
+			continue
+		}
+		data[k] = &obj
+	}
+	return data, nil
+}
+
+// TestLayeredSetReturnsEmbeddedError asserts the embedded layer's Set error is
+// propagated to the caller of Layered.Set instead of being silently swallowed.
+func TestLayeredSetReturnsEmbeddedError(t *testing.T) {
+	t.Parallel()
+
+	embeddedErr := errors.New("disk full")
+	embedded := &faultyEmbeddedLayer{inner: NewMemoryLayer(), setErr: embeddedErr}
+	s := New(LayeredConfig{Memory: NewMemoryLayer(), Embedded: embedded})
+	require.NoError(t, s.Start(Options{}))
+	defer s.Close()
+
+	_, err := s.Set("k", json.RawMessage(`{"v":1}`))
+	require.ErrorIs(t, err, embeddedErr,
+		"Set must return the embedded layer's error")
+}
+
+// TestLayeredPushReturnsEmbeddedError is the Push variant.
+func TestLayeredPushReturnsEmbeddedError(t *testing.T) {
+	t.Parallel()
+
+	embeddedErr := errors.New("disk full")
+	embedded := &faultyEmbeddedLayer{inner: NewMemoryLayer(), setErr: embeddedErr}
+	s := New(LayeredConfig{Memory: NewMemoryLayer(), Embedded: embedded})
+	require.NoError(t, s.Start(Options{}))
+	defer s.Close()
+
+	_, err := s.Push("things/*", json.RawMessage(`{"v":1}`))
+	require.ErrorIs(t, err, embeddedErr,
+		"Push must return the embedded layer's error")
+}
+
+// TestLayeredSetWithMetaReturnsEmbeddedError is the SetWithMeta variant.
+func TestLayeredSetWithMetaReturnsEmbeddedError(t *testing.T) {
+	t.Parallel()
+
+	embeddedErr := errors.New("disk full")
+	embedded := &faultyEmbeddedLayer{inner: NewMemoryLayer(), setErr: embeddedErr}
+	s := New(LayeredConfig{Memory: NewMemoryLayer(), Embedded: embedded})
+	require.NoError(t, s.Start(Options{}))
+	defer s.Close()
+
+	_, err := s.SetWithMeta("k", json.RawMessage(`{"v":1}`), 1, 2)
+	require.ErrorIs(t, err, embeddedErr,
+		"SetWithMeta must return the embedded layer's error")
+}
+
+// TestLayeredDelReturnsEmbeddedError asserts the embedded layer's Del error is
+// propagated to the caller of Layered.Del.
+func TestLayeredDelReturnsEmbeddedError(t *testing.T) {
+	t.Parallel()
+
+	embeddedErr := errors.New("disk locked")
+	embedded := &faultyEmbeddedLayer{inner: NewMemoryLayer()}
+	s := New(LayeredConfig{Memory: NewMemoryLayer(), Embedded: embedded})
+	require.NoError(t, s.Start(Options{}))
+	defer s.Close()
+
+	_, err := s.Set("k", json.RawMessage(`{"v":1}`))
+	require.NoError(t, err)
+
+	embedded.delErr = embeddedErr
+
+	err = s.Del("k")
+	require.ErrorIs(t, err, embeddedErr,
+		"Del must return the embedded layer's error")
 }


### PR DESCRIPTION
## Summary
Closes #55 — when the durable storage layer cannot persist a write, the storage call returns the error and the broadcast is suppressed.

- Callers now find out when a write didn't durably commit, instead of getting `nil` and a misleading "everything's fine".
- Subscribers are no longer notified about writes that didn't reach disk.
- All four mutators (`Set`, `Push`, `SetWithMeta`, `Del`) and the silent variant (`DelSilent`) follow the same rule.
- Behavior on success is unchanged.

## Trade-off note
The memory layer keeps the new value on embedded failure (the storage is memory-first by design); a restart restores the prior committed value from disk. Callers that need rollback semantics should retry on error or fall back to the prior state explicitly. This is documented in the `setLocked` godoc.

## Test plan
- [ ] Four new tests cover Set, Push, SetWithMeta, and Del using a fault-injecting embedded layer; each asserts the configured embedded error is returned to the caller.
- [ ] All four tests fail on `main` and pass on this branch.
- [ ] Existing storage tests pass.
- [ ] Full test suite passes under `-race`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)