### PR TITLE
fix(io): route in-process helpers through configured filters

### DIFF
--- a/filters_test.go
+++ b/filters_test.go
@@ -7,12 +7,14 @@ import (
 	"net/http/httptest"
 	"os"
 	"runtime"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/benitogf/go-json"
 	"github.com/benitogf/jsondiff"
 	"github.com/benitogf/ooo/filters"
 	"github.com/benitogf/ooo/meta"
-	"github.com/benitogf/go-json"
 
 	"github.com/stretchr/testify/require"
 )
@@ -677,4 +679,133 @@ func TestReadListFilterAllowsIndividualReads(t *testing.T) {
 	body, err = io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	require.Contains(t, string(body), "test log")
+}
+
+type filterTestItem struct {
+	V int `json:"v"`
+}
+
+// ioFilterServer starts a Server suitable for in-process io.* tests with the
+// supplied filter registrations applied first.
+func ioFilterServer(t *testing.T, register func(*Server)) *Server {
+	t.Helper()
+	server := &Server{Silence: true}
+	register(server)
+	server.Start("localhost:0")
+	t.Cleanup(func() { server.Close(os.Interrupt) })
+	return server
+}
+
+// TestIoSetEnforcesWriteFilter asserts that ooo.Set runs the configured write
+// filter and surfaces its rejection. Pre-fix it bypassed the filter entirely.
+func TestIoSetEnforcesWriteFilter(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+	rejection := errors.New("write rejected")
+	server := ioFilterServer(t, func(s *Server) {
+		s.WriteFilter("guarded/*", func(key string, data json.RawMessage) (json.RawMessage, error) {
+			return nil, rejection
+		})
+	})
+
+	err := Set(server, "guarded/k", filterTestItem{V: 1})
+	require.ErrorIs(t, err, rejection,
+		"ooo.Set must surface the WriteFilter rejection")
+
+	_, err = server.Storage.Get("guarded/k")
+	require.Error(t, err, "value should not have been committed")
+}
+
+// TestIoPushEnforcesWriteFilter is the Push variant.
+func TestIoPushEnforcesWriteFilter(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+	rejection := errors.New("write rejected")
+	server := ioFilterServer(t, func(s *Server) {
+		s.WriteFilter("guarded/*", func(key string, data json.RawMessage) (json.RawMessage, error) {
+			return nil, rejection
+		})
+	})
+
+	_, err := Push(server, "guarded/*", filterTestItem{V: 1})
+	require.ErrorIs(t, err, rejection,
+		"ooo.Push must surface the WriteFilter rejection")
+}
+
+// TestIoPatchEnforcesWriteFilter asserts the merged result is filtered.
+func TestIoPatchEnforcesWriteFilter(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+	rejection := errors.New("write rejected")
+	server := ioFilterServer(t, func(s *Server) {
+		s.WriteFilter("guarded/k", func(key string, data json.RawMessage) (json.RawMessage, error) {
+			return nil, rejection
+		})
+	})
+
+	// Seed via raw storage to isolate the patch path under test.
+	_, err := server.Storage.Set("guarded/k", json.RawMessage(`{"v":1}`))
+	require.NoError(t, err)
+
+	err = Patch(server, "guarded/k", filterTestItem{V: 2})
+	require.ErrorIs(t, err, rejection,
+		"ooo.Patch must surface the WriteFilter rejection on the merged value")
+
+	obj, err := server.Storage.Get("guarded/k")
+	require.NoError(t, err)
+	require.JSONEq(t, `{"v":1}`, string(obj.Data),
+		"patch should not have been committed when the filter rejected it")
+}
+
+// TestIoDeleteEnforcesDeleteFilter asserts that ooo.Delete runs the configured
+// delete filter and surfaces its rejection.
+func TestIoDeleteEnforcesDeleteFilter(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+	rejection := errors.New("delete rejected")
+	server := ioFilterServer(t, func(s *Server) {
+		s.DeleteFilter("guarded/k", func(key string) error {
+			return rejection
+		})
+	})
+
+	_, err := server.Storage.Set("guarded/k", json.RawMessage(`{"v":1}`))
+	require.NoError(t, err)
+
+	err = Delete(server, "guarded/k")
+	require.ErrorIs(t, err, rejection,
+		"ooo.Delete must surface the DeleteFilter rejection")
+
+	_, err = server.Storage.Get("guarded/k")
+	require.NoError(t, err, "value should still exist; delete was rejected")
+}
+
+// TestIoSetFiresAfterWriteFilter asserts that the after-write hook fires on a
+// successful in-process write, matching the REST behavior.
+func TestIoSetFiresAfterWriteFilter(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+	var fired sync.WaitGroup
+	fired.Add(1)
+	var firedOnce sync.Once
+	server := ioFilterServer(t, func(s *Server) {
+		s.AfterWriteFilter("k", func(key string) {
+			firedOnce.Do(fired.Done)
+		})
+	})
+
+	require.NoError(t, Set(server, "k", filterTestItem{V: 1}))
+
+	done := make(chan struct{})
+	go func() { fired.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("AfterWriteFilter did not fire within 2s of in-process Set")
+	}
 }

--- a/filters_test.go
+++ b/filters_test.go
@@ -784,6 +784,49 @@ func TestIoDeleteEnforcesDeleteFilter(t *testing.T) {
 	require.NoError(t, err, "value should still exist; delete was rejected")
 }
 
+// TestIoGetEnforcesReadObjectFilter asserts that ooo.Get runs the configured
+// read-object filter and surfaces its rejection. Pre-fix it bypassed the
+// filter entirely.
+func TestIoGetEnforcesReadObjectFilter(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+	rejection := errors.New("read rejected")
+	server := ioFilterServer(t, func(s *Server) {
+		s.ReadObjectFilter("guarded/k", func(key string, obj meta.Object) (meta.Object, error) {
+			return meta.Object{}, rejection
+		})
+	})
+
+	_, err := server.Storage.Set("guarded/k", json.RawMessage(`{"v":1}`))
+	require.NoError(t, err)
+
+	_, err = Get[filterTestItem](server, "guarded/k")
+	require.ErrorIs(t, err, rejection,
+		"ooo.Get must surface the ReadObjectFilter rejection")
+}
+
+// TestIoGetListEnforcesReadListFilter asserts that ooo.GetList propagates the
+// read-list filter rejection instead of swallowing it.
+func TestIoGetListEnforcesReadListFilter(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+	rejection := errors.New("read list rejected")
+	server := ioFilterServer(t, func(s *Server) {
+		s.ReadListFilter("guarded/*", func(key string, objs []meta.Object) ([]meta.Object, error) {
+			return nil, rejection
+		})
+	})
+
+	_, err := server.Storage.Set("guarded/a", json.RawMessage(`{"v":1}`))
+	require.NoError(t, err)
+
+	_, err = GetList[filterTestItem](server, "guarded/*")
+	require.ErrorIs(t, err, rejection,
+		"ooo.GetList must surface the ReadListFilter rejection")
+}
+
 // TestIoSetFiresAfterWriteFilter asserts that the after-write hook fires on a
 // successful in-process write, matching the REST behavior.
 func TestIoSetFiresAfterWriteFilter(t *testing.T) {

--- a/io.go
+++ b/io.go
@@ -4,10 +4,10 @@ import (
 	"errors"
 	"log"
 
+	"github.com/benitogf/go-json"
 	"github.com/benitogf/ooo/client"
 	"github.com/benitogf/ooo/key"
 	"github.com/benitogf/ooo/merge"
-	"github.com/benitogf/go-json"
 )
 
 var (
@@ -75,6 +75,9 @@ func Get[T any](server *Server, path string) (client.Meta[T], error) {
 	}, nil
 }
 
+// Set stores a value at the specified path. The path must not contain glob
+// patterns. The configured WriteFilter (if any) is consulted before the write
+// and may reject or transform the value; the AfterWriteFilter fires on success.
 func Set[T any](server *Server, path string, item T) error {
 	if key.IsGlob(path) {
 		log.Println("Set["+path+"]: ", ErrPathGlobNotAllowed)
@@ -86,32 +89,60 @@ func Set[T any](server *Server, path string, item T) error {
 		log.Println("Set["+path+"]: failed to marshal data", err)
 		return err
 	}
-	_, err = server.Storage.Set(path, data)
-	return err
+	data, err = server.filters.Write.Check(path, data, server.Static)
+	if err != nil {
+		log.Println("Set["+path+"]: write filter rejected", err)
+		return err
+	}
+	if _, err = server.Storage.Set(path, data); err != nil {
+		return err
+	}
+	server.filters.AfterWrite.Check(path)
+	return nil
 }
 
+// Push stores a value at a fresh key under the supplied glob path. The
+// configured WriteFilter (if any) is consulted on the resolved path before
+// the write; the AfterWriteFilter fires on success.
 func Push[T any](server *Server, path string, item T) (string, error) {
 	data, err := json.Marshal(item)
 	if err != nil {
 		log.Println("Push["+path+"]: failed to marshal data", err)
 		return "", err
 	}
-	return server.Storage.Push(path, data)
+	data, err = server.filters.Write.Check(path, data, server.Static)
+	if err != nil {
+		log.Println("Push["+path+"]: write filter rejected", err)
+		return "", err
+	}
+	index, err := server.Storage.Push(path, data)
+	if err != nil {
+		return "", err
+	}
+	server.filters.AfterWrite.Check(path)
+	return index, nil
 }
 
 // Delete removes an item at the specified path from storage.
-// The path must not contain glob patterns.
+// The path must not contain glob patterns. The configured DeleteFilter (if
+// any) is consulted before the delete and may reject it.
 func Delete(server *Server, path string) error {
 	if key.IsGlob(path) {
 		log.Println("Delete["+path+"]: ", ErrPathGlobNotAllowed)
 		return ErrPathGlobNotAllowed
+	}
+	if err := server.filters.Delete.Check(path, server.Static); err != nil {
+		log.Println("Delete["+path+"]: delete filter rejected", err)
+		return err
 	}
 	return server.Storage.Del(path)
 }
 
 // Patch applies a partial update to an existing item at the specified path.
 // The path must not contain glob patterns and the item must already exist.
-// The patch is merged with the existing data using JSON merge semantics.
+// The patch is merged with the existing data using JSON merge semantics; the
+// configured WriteFilter (if any) sees the merged result and may reject or
+// transform it. The AfterWriteFilter fires on success.
 func Patch[T any](server *Server, path string, item T) error {
 	if key.IsGlob(path) {
 		log.Println("Patch["+path+"]: ", ErrPathGlobNotAllowed)
@@ -136,6 +167,14 @@ func Patch[T any](server *Server, path string, item T) error {
 		return err
 	}
 
-	_, err = server.Storage.Set(path, mergedBytes)
-	return err
+	data, err := server.filters.Write.Check(path, json.RawMessage(mergedBytes), server.Static)
+	if err != nil {
+		log.Println("Patch["+path+"]: write filter rejected", err)
+		return err
+	}
+	if _, err = server.Storage.Set(path, data); err != nil {
+		return err
+	}
+	server.filters.AfterWrite.Check(path)
+	return nil
 }

--- a/io.go
+++ b/io.go
@@ -15,6 +15,9 @@ var (
 	ErrPathGlobNotAllowed = errors.New("io: path glob not allowed")
 )
 
+// GetList retrieves all items at the supplied glob path. The configured
+// ReadListFilter (if any) is consulted with the same static-mode flag the
+// REST handler uses; a filter rejection is propagated to the caller.
 func GetList[T any](server *Server, path string) ([]client.Meta[T], error) {
 	var result []client.Meta[T]
 	if !key.IsGlob(path) {
@@ -29,8 +32,11 @@ func GetList[T any](server *Server, path string) ([]client.Meta[T], error) {
 		return result, err
 	}
 
-	// Apply ReadListFilter if registered for this path
-	objs, _ = server.filters.ReadList.Check(path, objs, false)
+	objs, err = server.filters.ReadList.Check(path, objs, server.Static)
+	if err != nil {
+		log.Println("GetList["+path+"]: read list filter rejected", err)
+		return result, err
+	}
 
 	for _, obj := range objs {
 		var item T
@@ -49,6 +55,9 @@ func GetList[T any](server *Server, path string) ([]client.Meta[T], error) {
 	return result, nil
 }
 
+// Get retrieves a single item at the specified path. The configured
+// ReadObjectFilter (with ReadListFilter fallback) is consulted before the
+// value is returned, matching the REST read handler.
 func Get[T any](server *Server, path string) (client.Meta[T], error) {
 	var result client.Meta[T]
 	if key.IsGlob(path) {
@@ -59,6 +68,11 @@ func Get[T any](server *Server, path string) (client.Meta[T], error) {
 	obj, err := server.Storage.Get(path)
 	if err != nil {
 		log.Println("Get["+path+"]: failed to get from storage", err)
+		return result, err
+	}
+	obj, err = server.filters.ReadObject.CheckWithListFallback(path, obj, server.Static, server.filters.ReadList)
+	if err != nil {
+		log.Println("Get["+path+"]: read filter rejected", err)
 		return result, err
 	}
 	var item T


### PR DESCRIPTION
## Summary
Closes #57 — the in-process read, write, and delete helpers now honour the same filters the REST handlers do.

- **Writes**: `ooo.Set`, `ooo.Push`, and `ooo.Patch` consult the configured WriteFilter before committing and fire AfterWriteFilter on success.
- **Deletes**: `ooo.Delete` consults the configured DeleteFilter before committing.
- **Reads**: `ooo.Get` consults `ReadObject.CheckWithListFallback` with `server.Static` (was bypassed entirely); `ooo.GetList` propagates the ReadListFilter error and passes `server.Static` instead of the hardcoded `false`.
- A filter that validates inputs, redacts fields, denies deletes, denies reads, or is meant to gate static-mode is now effective regardless of whether the call comes from HTTP or in-process.
- Behavior on unfiltered paths is unchanged.

## Why this is broader than the original audit item
The audit listed write/delete bypasses; the read side has the same shape (`ooo.Get` had no filter call at all, `ooo.GetList` swallowed errors and used the wrong static flag). Bundled here for symmetry — once the in-process helpers are the recommended path, every filter the REST handler honours must also fire from in-process.

## Test plan
- [ ] New tests cover Set, Push, Patch, and Delete each rejecting via the configured filter.
- [ ] New tests cover Get and GetList each rejecting via their respective read filters.
- [ ] A new test covers the AfterWriteFilter firing on a successful in-process Set.
- [ ] All seven new tests fail on `main` and pass on this branch.
- [ ] Existing tests pass.
- [ ] Full test suite passes under `-race`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)