### PR TITLE
fix(patch): surface merge info.Errors instead of silently committing

### DIFF
--- a/filters_test.go
+++ b/filters_test.go
@@ -760,6 +760,30 @@ func TestIoPatchEnforcesWriteFilter(t *testing.T) {
 		"patch should not have been committed when the filter rejected it")
 }
 
+// TestIoPatchRejectsTypeMismatch asserts that ooo.Patch surfaces non-fatal
+// merge errors (type mismatches at specific paths) instead of silently
+// persisting a partially-merged result.
+func TestIoPatchRejectsTypeMismatch(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+	server := ioFilterServer(t, func(s *Server) {})
+
+	_, err := server.Storage.Set("typemismatch/k", json.RawMessage(`{"nest":{"x":1},"name":"a"}`))
+	require.NoError(t, err)
+
+	// Patch tries to overwrite "nest" (object) with a primitive — merge keeps
+	// the original value at that path. Patch must return an error rather than
+	// committing the partially-applied result.
+	err = Patch(server, "typemismatch/k", map[string]any{"nest": "replaced", "name": "b"})
+	require.Error(t, err, "ooo.Patch must reject patches with type-mismatch merge errors")
+
+	obj, err := server.Storage.Get("typemismatch/k")
+	require.NoError(t, err)
+	require.JSONEq(t, `{"nest":{"x":1},"name":"a"}`, string(obj.Data),
+		"patch should not have been committed when merge reported errors")
+}
+
 // TestIoDeleteEnforcesDeleteFilter asserts that ooo.Delete runs the configured
 // delete filter and surfaces its rejection.
 func TestIoDeleteEnforcesDeleteFilter(t *testing.T) {

--- a/io.go
+++ b/io.go
@@ -182,10 +182,18 @@ func Patch[T any](server *Server, path string, item T) error {
 		return err
 	}
 
-	mergedBytes, _, err := merge.MergeBytes(currentObj.Data, patchData)
+	mergedBytes, info, err := merge.MergeBytes(currentObj.Data, patchData)
 	if err != nil {
 		log.Println("Patch["+path+"]: failed to merge data", err)
 		return err
+	}
+	// Non-fatal merge errors (e.g. type mismatch at a specific path) leave
+	// the original value in place at that path. Surface them rather than
+	// silently committing a partially-applied patch.
+	if len(info.Errors) > 0 {
+		joined := errors.Join(info.Errors...)
+		log.Println("Patch["+path+"]: merge reported errors", joined)
+		return joined
 	}
 
 	// See note in GetList: in-process helpers do not enforce Static mode.

--- a/rest.go
+++ b/rest.go
@@ -7,12 +7,12 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/benitogf/go-json"
 	"github.com/benitogf/ooo/key"
 	"github.com/benitogf/ooo/merge"
 	"github.com/benitogf/ooo/messages"
 	"github.com/benitogf/ooo/meta"
 	"github.com/benitogf/ooo/stream"
-	"github.com/benitogf/go-json"
 	"github.com/gorilla/mux"
 )
 
@@ -103,10 +103,19 @@ func (server *Server) patch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	mergedBytes, _, err := merge.MergeBytes(currentObj.Data, patchData)
+	mergedBytes, info, err := merge.MergeBytes(currentObj.Data, patchData)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		fmt.Fprintf(w, "%s", err)
+		return
+	}
+	// Non-fatal merge errors (e.g. type mismatch at a specific path) leave
+	// the original value in place at that path. Persisting silently would
+	// confirm a 200 for a partially-applied patch.
+	if len(info.Errors) > 0 {
+		server.Console.Err("patchError["+_key+"]", info.Errors)
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintf(w, "%s", errors.Join(info.Errors...))
 		return
 	}
 

--- a/rest_test.go
+++ b/rest_test.go
@@ -10,9 +10,9 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/benitogf/go-json"
 	"github.com/benitogf/ooo"
 	"github.com/benitogf/ooo/meta"
-	"github.com/benitogf/go-json"
 	"github.com/stretchr/testify/require"
 )
 
@@ -413,6 +413,35 @@ func TestRestPatchWriteFilterOnMergedData(t *testing.T) {
 	// Both fields should exist: requiredField from original, otherField patched
 	require.Equal(t, "exists", result["requiredField"])
 	require.Equal(t, "patched", result["otherField"])
+}
+
+func TestRestPatchTypeMismatchRejected(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+	server := ooo.Server{}
+	server.Silence = true
+	server.Start("localhost:0")
+	defer server.Close(os.Interrupt)
+
+	// Existing data has "nest" as an object.
+	_, err := server.Storage.Set("typemismatch", json.RawMessage(`{"nest":{"x":1},"name":"a"}`))
+	require.NoError(t, err)
+
+	// Patch tries to overwrite "nest" with a primitive — merge silently keeps
+	// the original value for that path. Without the fix, the caller sees 200
+	// but the storage has not changed for "nest".
+	patchBody := []byte(`{"nest":"replaced","name":"b"}`)
+	req := httptest.NewRequest(http.MethodPatch, "/typemismatch", bytes.NewBuffer(patchBody))
+	w := httptest.NewRecorder()
+	server.Router.ServeHTTP(w, req)
+	resp := w.Result()
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	// Storage must remain unchanged when the patch is rejected.
+	obj, err := server.Storage.Get("typemismatch")
+	require.NoError(t, err)
+	require.JSONEq(t, `{"nest":{"x":1},"name":"a"}`, string(obj.Data))
 }
 
 func TestRestInvalidKey(t *testing.T) {


### PR DESCRIPTION
## Summary
- Both `rest.patch` and `io.Patch` discarded the `*merge.Info` returned by `MergeBytes`. Non-fatal errors (e.g. type mismatch at a specific path) silently dropped the offending key from the patch and persisted the rest, returning HTTP 200 / `nil`.
- Surface `info.Errors`: REST → 400 with joined errors, no persist. `io.Patch` → return joined error, no persist.

## Test plan
- [x] `TestRestPatchTypeMismatchRejected` — pre-fix returns 200 and stores the partially-merged value; post-fix returns 400 and storage is unchanged.
- [x] `TestIoPatchRejectsTypeMismatch` — pre-fix returns nil; post-fix returns the joined merge error.
- [x] `go test -race ./...` clean.

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)