### PR TITLE
fix(ooo): cancel handler contexts on Close + stop nilling Server fields

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -25,7 +25,13 @@ type MethodSpec struct {
 // Methods maps HTTP method to its specification
 type Methods map[string]MethodSpec
 
-// EndpointConfig configures a custom endpoint
+// EndpointConfig configures a custom endpoint.
+//
+// Handler contract: long-running handlers must respect r.Context().Done().
+// Server.Close gives handlers a graceful window of server.Deadline to exit,
+// then force-closes connections to cancel their request contexts. A handler
+// that ignores the context will leak its goroutine — Go offers no way to
+// preempt it.
 type EndpointConfig struct {
 	Path        string
 	Methods     Methods

--- a/ooo.go
+++ b/ooo.go
@@ -717,12 +717,19 @@ func (server *Server) Close(sig os.Signal) {
 		// Force close all stream connections first
 		server.Stream.CloseAll()
 		// Shutdown HTTP server to stop accepting new connections. Bound the
-		// context by Deadline so a stuck handler cannot block shutdown
-		// indefinitely (Endpoint handlers are not wrapped in TimeoutHandler).
+		// graceful window by Deadline so a stuck handler cannot block
+		// shutdown indefinitely. Custom Endpoint handlers are not wrapped
+		// in TimeoutHandler, so they must respect r.Context().Done() to
+		// exit cleanly during this window.
+		//
+		// After the graceful window, force-close to cancel any still-running
+		// request contexts. Handlers that honour the context exit then;
+		// handlers that ignore it leak (they cannot be killed in Go).
 		if server.server != nil {
 			shutdownCtx, cancel := context.WithTimeout(context.Background(), server.Deadline)
 			server.server.Shutdown(shutdownCtx)
 			cancel()
+			server.server.Close()
 		}
 		server.handlerWg.Wait() // Wait for HTTP handlers to finish
 		server.listenWg.Wait()  // Wait for listen goroutine to finish
@@ -730,18 +737,12 @@ func (server *Server) Close(sig os.Signal) {
 		server.watchWg.Wait() // Wait for watch goroutines to finish
 		server.OnClose()
 		server.Console.Err("shutdown", sig)
-		// Clear server state to allow restarting
-		server.server = nil
-		server.Router = nil
-		server.Stream = stream.Stream{}
-		server.Storage = nil
-		server.Console = nil
-		server.filters = filters.Filters{}
-		server.limitFilters = nil
-		server.endpoints = nil
-		server.proxies = nil
-		server.startErr = nil
-		server.clockStop = nil
+		// Do not nil out Storage / Router / Console / Stream / filters here.
+		// PR #63 made shutdown bounded by Deadline, which means a stuck
+		// handler can outlive Close; nilling these fields with no
+		// synchronisation would let that goroutine nil-deref. Leaving the
+		// fields populated keeps post-close calls error-returning rather
+		// than panicking.
 	}
 }
 

--- a/ooo_test.go
+++ b/ooo_test.go
@@ -2,6 +2,7 @@ package ooo
 
 import (
 	"bytes"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -93,7 +94,7 @@ func TestServerValidate(t *testing.T) {
 	require.Contains(t, err.Error(), "Deadline cannot be negative")
 }
 
-func TestCloseResetsState(t *testing.T) {
+func TestCloseMarksServerInactive(t *testing.T) {
 	server := Server{}
 	server.Silence = true
 	server.Start("localhost:0")
@@ -103,9 +104,9 @@ func TestCloseResetsState(t *testing.T) {
 
 	server.Close(os.Interrupt)
 
-	// After close, internal state should be cleared
-	require.Nil(t, server.Router)
-	require.Nil(t, server.Storage)
+	// Close marks the server inactive; the field references stay populated
+	// so leaked handlers / callbacks don't nil-deref.
+	require.False(t, server.Active())
 }
 
 // TestServerCloseShutdownBoundedByDeadline asserts that Server.Close does not
@@ -177,6 +178,146 @@ func TestServerCloseShutdownBoundedByDeadline(t *testing.T) {
 	// handler exit before the test ends.
 	close(unblock)
 	requestExited.Wait()
+}
+
+// TestServerCloseCancelsHandlerContext asserts that Server.Close cancels
+// in-flight request contexts so well-behaved handlers (those that respect
+// r.Context().Done()) exit cleanly. Without the post-Shutdown force-close,
+// stdlib Shutdown timing out leaves request contexts uncancelled and the
+// handler goroutine leaks.
+func TestServerCloseCancelsHandlerContext(t *testing.T) {
+	server := &Server{
+		Silence:  true,
+		Deadline: 200 * time.Millisecond,
+	}
+
+	var entered sync.WaitGroup
+	entered.Add(1)
+	var enteredOnce sync.Once
+
+	var handlerExited sync.WaitGroup
+	handlerExited.Add(1)
+	var handlerOnce sync.Once
+	var contextCancelled atomic.Bool
+
+	server.Start("localhost:0")
+	server.Endpoint(EndpointConfig{
+		Path: "/context-aware-handler",
+		Methods: Methods{
+			http.MethodGet: {Response: nil},
+		},
+		Handler: func(w http.ResponseWriter, r *http.Request) {
+			defer handlerOnce.Do(handlerExited.Done)
+			enteredOnce.Do(entered.Done)
+			// Well-behaved handler: block until the request context is
+			// cancelled. Close should cancel it via force-close.
+			<-r.Context().Done()
+			contextCancelled.Store(true)
+		},
+	})
+
+	var requestExited sync.WaitGroup
+	requestExited.Add(1)
+	go func() {
+		defer requestExited.Done()
+		client := &http.Client{Timeout: 30 * time.Second}
+		req, _ := http.NewRequest(http.MethodGet, "http://"+server.Address+"/context-aware-handler", nil)
+		resp, err := client.Do(req)
+		if err == nil && resp != nil {
+			resp.Body.Close()
+		}
+	}()
+
+	entered.Wait()
+
+	server.Close(os.Interrupt)
+
+	// Bound waits: handler must have exited via ctx.Done() by the time
+	// Close returned (or shortly after the force-close took effect).
+	exitedDone := make(chan struct{})
+	go func() {
+		handlerExited.Wait()
+		close(exitedDone)
+	}()
+	select {
+	case <-exitedDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler did not exit after Server.Close — request context was not cancelled")
+	}
+	requestExited.Wait()
+
+	require.True(t, contextCancelled.Load(),
+		"handler should have observed r.Context().Done() during Close")
+}
+
+// TestServerCloseDoesNotNilFieldsUnderHandler asserts that Server.Close does
+// not nil fields like Storage out from under a leaked handler goroutine.
+// Pre-fix, Close cleared server.Storage = nil with no synchronisation; a
+// handler that resumed after Close panicked on nil deref.
+func TestServerCloseDoesNotNilFieldsUnderHandler(t *testing.T) {
+	server := &Server{
+		Silence:  true,
+		Deadline: 200 * time.Millisecond,
+	}
+
+	var entered sync.WaitGroup
+	entered.Add(1)
+	var enteredOnce sync.Once
+
+	unblock := make(chan struct{})
+
+	var handlerExited sync.WaitGroup
+	handlerExited.Add(1)
+	var handlerOnce sync.Once
+	var handlerPanic atomic.Value
+
+	server.Start("localhost:0")
+	server.Endpoint(EndpointConfig{
+		Path: "/leaky-handler",
+		Methods: Methods{
+			http.MethodGet: {Response: nil},
+		},
+		Handler: func(w http.ResponseWriter, r *http.Request) {
+			defer handlerOnce.Do(handlerExited.Done)
+			defer func() {
+				if rec := recover(); rec != nil {
+					handlerPanic.Store(fmt.Sprintf("%v", rec))
+				}
+			}()
+			enteredOnce.Do(entered.Done)
+			<-unblock
+			// Touch a field that Close used to nil. Pre-fix this panics
+			// with nil pointer dereference; post-fix the call returns
+			// without panic (Storage may be closed but the field is non-nil).
+			_, _ = server.Storage.Get("never-set")
+		},
+	})
+
+	var requestExited sync.WaitGroup
+	requestExited.Add(1)
+	go func() {
+		defer requestExited.Done()
+		client := &http.Client{Timeout: 30 * time.Second}
+		req, _ := http.NewRequest(http.MethodGet, "http://"+server.Address+"/leaky-handler", nil)
+		resp, err := client.Do(req)
+		if err == nil && resp != nil {
+			resp.Body.Close()
+		}
+	}()
+
+	entered.Wait()
+
+	server.Close(os.Interrupt)
+
+	// Release the leaked handler. Pre-fix, the handler now nil-derefs
+	// because Close cleared server.Storage.
+	close(unblock)
+	handlerExited.Wait()
+	requestExited.Wait()
+
+	if v := handlerPanic.Load(); v != nil {
+		t.Fatalf("handler panicked after Server.Close: %v", v)
+	}
 }
 
 func TestStartWithError(t *testing.T) {


### PR DESCRIPTION
## Summary

Two problems exposed after PR #63 bounded HTTP shutdown by `Deadline`:

1. **Handlers leak silently.** Stdlib `Shutdown(ctx)` returning on context expiry does *not* cancel in-flight request contexts. A well-behaved handler that respects `r.Context().Done()` never sees the signal and goroutine-leaks. Fix: call `server.server.Close()` after `Shutdown` to force-close connections, which cancels their request contexts.
2. **Fields nilled under live handlers.** `Close` cleared `Storage / Router / Console / Stream / filters / ...` with no synchronisation. Leaked handler goroutines (or any user goroutine holding `*Server`) nil-deref on next access. Fix: drop the nilling block.

Document the contract on `EndpointConfig`: long-running handlers must respect `r.Context().Done()` to participate in clean shutdown. Handlers that ignore the context cannot be preempted — Go has no goroutine kill.

## Test plan
- [x] `TestServerCloseCancelsHandlerContext` — well-behaved handler blocks on `r.Context().Done()`; after `Close` it must observe cancellation and exit. Pre-fix (no force-close) it hangs past 2s; post-fix it exits in ~Deadline.
- [x] `TestServerCloseDoesNotNilFieldsUnderHandler` — leaked handler resumes after `Close` and accesses `server.Storage`. Pre-fix nil-derefs; post-fix completes.
- [x] `TestCloseResetsState` → `TestCloseMarksServerInactive` reflects the new contract.
- [x] `TestServerCloseShutdownBoundedByDeadline` (from PR #63) still green.
- [x] `go test -race ./...` clean.

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)