### PR TITLE
refactor(ooo): move test helpers to sibling oootest package

### DIFF
--- a/filters_test.go
+++ b/filters_test.go
@@ -19,6 +19,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// fixturePostBody is a minimal valid JSON body used as POST payload in the
+// internal-package filter tests. The oootest package holds richer fixtures,
+// but importing oootest from package ooo would create a cycle.
+var fixturePostBody = json.RawMessage(`{"sample":true}`)
+
 func TestFilters(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Parallel()
@@ -101,7 +106,7 @@ func TestFilters(t *testing.T) {
 	require.NoError(t, err)
 	_, err = server.filters.ReadList.Check("book/1", nil, true)
 	require.NoError(t, err)
-	req := httptest.NewRequest("POST", "/test/1", bytes.NewBuffer(TEST_DATA))
+	req := httptest.NewRequest("POST", "/test/1", bytes.NewBuffer(fixturePostBody))
 	w := httptest.NewRecorder()
 	server.Router.ServeHTTP(w, req)
 	resp := w.Result()
@@ -113,7 +118,7 @@ func TestFilters(t *testing.T) {
 	resp = w.Result()
 	require.Equal(t, 200, resp.StatusCode)
 
-	req = httptest.NewRequest("POST", "/flyer", bytes.NewBuffer(TEST_DATA))
+	req = httptest.NewRequest("POST", "/flyer", bytes.NewBuffer(fixturePostBody))
 	w = httptest.NewRecorder()
 	server.Router.ServeHTTP(w, req)
 	resp = w.Result()

--- a/memory_bench_test.go
+++ b/memory_bench_test.go
@@ -1,17 +1,20 @@
-package ooo
+package ooo_test
 
 import (
 	"os"
 	"testing"
+
+	"github.com/benitogf/ooo"
+	"github.com/benitogf/ooo/oootest"
 )
 
 // go test -bench=.
 
 func BenchmarkMemoryStorageSetGetDel(b *testing.B) {
 	b.ReportAllocs()
-	server := Server{}
+	server := ooo.Server{}
 	server.Silence = true
 	server.Start("localhost:9889")
 	defer server.Close(os.Interrupt)
-	StorageSetGetDelTestBenchmark(server.Storage, b)
+	oootest.StorageSetGetDelTestBenchmark(server.Storage, b)
 }

--- a/memory_test.go
+++ b/memory_test.go
@@ -1,11 +1,13 @@
-package ooo
+package ooo_test
 
 import (
 	"os"
 	"runtime"
 	"testing"
 
+	"github.com/benitogf/ooo"
 	"github.com/benitogf/ooo/monotonic"
+	"github.com/benitogf/ooo/oootest"
 	"github.com/benitogf/ooo/storage"
 	"github.com/stretchr/testify/require"
 )
@@ -18,170 +20,170 @@ func TestStorage(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Parallel()
 	}
-	app := &Server{}
+	app := &ooo.Server{}
 	app.Silence = true
 	app.Start("localhost:0")
 	defer app.Close(os.Interrupt)
-	StorageListTest(app, t)
-	StorageObjectTest(app, t)
+	oootest.StorageListTest(app, t)
+	oootest.StorageObjectTest(app, t)
 }
 
 func TestStreamBroadcast(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Parallel()
 	}
-	server := Server{}
+	server := ooo.Server{}
 	server.Silence = true
 	server.ForcePatch = true
 	server.Start("localhost:0")
 	defer server.Close(os.Interrupt)
-	StreamBroadcastTest(t, &server)
+	oootest.StreamBroadcastTest(t, &server)
 }
 
 func TestStreamGlobBroadcast(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Parallel()
 	}
-	server := Server{}
+	server := ooo.Server{}
 	server.Silence = true
 	server.ForcePatch = true
 	server.Start("localhost:0")
 	defer server.Close(os.Interrupt)
-	StreamGlobBroadcastTest(t, &server, 3)
+	oootest.StreamGlobBroadcastTest(t, &server, 3)
 }
 
 func TestStreamGlobBroadcastConcurrent(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Parallel()
 	}
-	server := Server{}
+	server := ooo.Server{}
 	server.Silence = true
 	server.ForcePatch = true
 	server.Start("localhost:0")
 	defer server.Close(os.Interrupt)
-	StreamGlobBroadcastConcurrentTest(t, &server, 3)
+	oootest.StreamGlobBroadcastConcurrentTest(t, &server, 3)
 }
 
 func TestStreamBroadcastFilter(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Parallel()
 	}
-	server := Server{}
+	server := ooo.Server{}
 	server.Silence = true
 	server.ForcePatch = true
 	defer server.Close(os.Interrupt)
-	StreamBroadcastFilterTest(t, &server)
+	oootest.StreamBroadcastFilterTest(t, &server)
 }
 
 func TestStreamForcePatch(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Parallel()
 	}
-	server := Server{}
+	server := ooo.Server{}
 	server.Silence = true
 	defer server.Close(os.Interrupt)
-	StreamBroadcastForcePatchTest(t, &server)
+	oootest.StreamBroadcastForcePatchTest(t, &server)
 }
 
 func TestStreamNoPatch(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Parallel()
 	}
-	server := Server{}
+	server := ooo.Server{}
 	server.Silence = true
 	defer server.Close(os.Interrupt)
-	StreamBroadcastNoPatchTest(t, &server)
+	oootest.StreamBroadcastNoPatchTest(t, &server)
 }
 
 func TestGetN(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Parallel()
 	}
-	server := &Server{}
+	server := &ooo.Server{}
 	server.Silence = true
 	server.Start("localhost:0")
 	defer server.Close(os.Interrupt)
-	StorageGetNTest(server, t, 10)
+	oootest.StorageGetNTest(server, t, 10)
 }
 
 func TestGetNRange(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Parallel()
 	}
-	server := &Server{}
+	server := &ooo.Server{}
 	server.Silence = true
 	server.Start("localhost:0")
 	defer server.Close(os.Interrupt)
-	StorageGetNRangeTest(server, t, 10)
+	oootest.StorageGetNRangeTest(server, t, 10)
 }
 
 func TestKeysRange(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Parallel()
 	}
-	server := &Server{}
+	server := &ooo.Server{}
 	server.Silence = true
 	server.Start("localhost:0")
 	defer server.Close(os.Interrupt)
-	StorageKeysRangeTest(server, t, 10)
+	oootest.StorageKeysRangeTest(server, t, 10)
 }
 
 func TestStreamItemGlobBroadcast(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Parallel()
 	}
-	server := Server{}
+	server := ooo.Server{}
 	server.Silence = true
 	server.ForcePatch = true
 	server.Start("localhost:0")
 	server.Storage.Clear()
 	defer server.Close(os.Interrupt)
-	StreamItemGlobBroadcastTest(t, &server)
+	oootest.StreamItemGlobBroadcastTest(t, &server)
 }
 
 func TestBatchSet(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Parallel()
 	}
-	server := &Server{}
+	server := &ooo.Server{}
 	server.Silence = true
 	server.Start("localhost:0")
 	defer server.Close(os.Interrupt)
-	StorageBatchSetTest(server, t, 10)
+	oootest.StorageBatchSetTest(server, t, 10)
 }
 
 func TestStreamPatch(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Parallel()
 	}
-	server := &Server{}
+	server := &ooo.Server{}
 	server.Silence = true
 	server.Start("localhost:0")
 	defer server.Close(os.Interrupt)
-	StreamBroadcastPatchTest(t, server)
+	oootest.StreamBroadcastPatchTest(t, server)
 }
 
 func TestStreamLimitFilter(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Parallel()
 	}
-	server := &Server{}
+	server := &ooo.Server{}
 	server.Silence = true
 	server.Start("localhost:0")
 	defer server.Close(os.Interrupt)
-	StreamLimitFilterTest(t, server)
+	oootest.StreamLimitFilterTest(t, server)
 }
 
 func TestClientCompatibility(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Parallel()
 	}
-	server := &Server{}
+	server := &ooo.Server{}
 	server.Silence = true
 	server.ForcePatch = true
 	server.Start("localhost:0")
 	defer server.Close(os.Interrupt)
-	ClientCompatibilityTest(t, server)
+	oootest.ClientCompatibilityTest(t, server)
 }
 
 func TestBeforeRead(t *testing.T) {
@@ -194,7 +196,7 @@ func TestBeforeRead(t *testing.T) {
 	err := db.Start(storage.Options{})
 	require.NoError(t, err)
 	defer db.Close()
-	StorageBeforeReadTest(db, t)
+	oootest.StorageBeforeReadTest(db, t)
 }
 
 func TestStorageAfterWrite(t *testing.T) {
@@ -207,7 +209,7 @@ func TestStorageAfterWrite(t *testing.T) {
 	err := db.Start(storage.Options{})
 	require.NoError(t, err)
 	defer db.Close()
-	StorageAfterWriteTest(db, t)
+	oootest.StorageAfterWriteTest(db, t)
 }
 
 func TestWatchStorageNoop(t *testing.T) {
@@ -220,5 +222,5 @@ func TestWatchStorageNoop(t *testing.T) {
 	err := db.Start(storage.Options{})
 	require.NoError(t, err)
 	defer db.Close()
-	WatchStorageNoopTest(db, t)
+	oootest.WatchStorageNoopTest(db, t)
 }

--- a/oootest/storage.go
+++ b/oootest/storage.go
@@ -1,4 +1,4 @@
-package ooo
+package oootest
 
 import (
 	"bytes"
@@ -12,6 +12,7 @@ import (
 	"github.com/benitogf/go-json"
 
 	"github.com/benitogf/jsondiff"
+	"github.com/benitogf/ooo"
 	"github.com/benitogf/ooo/key"
 	"github.com/benitogf/ooo/meta"
 	"github.com/benitogf/ooo/monotonic"
@@ -856,7 +857,7 @@ var TEST_DATA_UPDATE = json.RawMessage(`{
   }`)
 
 // StorageObjectTest testing storage function
-func StorageObjectTest(server *Server, t *testing.T) {
+func StorageObjectTest(server *ooo.Server, t *testing.T) {
 	server.Storage.Clear()
 	index, err := server.Storage.Set("test", TEST_DATA)
 	require.NoError(t, err)
@@ -880,7 +881,7 @@ func StorageObjectTest(server *Server, t *testing.T) {
 }
 
 // StorageListTest testing storage function
-func StorageListTest(server *Server, t *testing.T) {
+func StorageListTest(server *ooo.Server, t *testing.T) {
 	server.Storage.Clear()
 	key, err := server.Storage.Set("test/123", TEST_DATA)
 	require.NoError(t, err)
@@ -993,7 +994,7 @@ func StorageSetGetDelTestBenchmark(db storage.Database, b *testing.B) {
 }
 
 // StorageGetNTest testing storage GetN function
-func StorageGetNTest(server *Server, t *testing.T, n int) {
+func StorageGetNTest(server *ooo.Server, t *testing.T, n int) {
 	server.Storage.Clear()
 	for i := range n {
 		value := strconv.Itoa(i)
@@ -1029,7 +1030,7 @@ func StorageGetNTest(server *Server, t *testing.T, n int) {
 }
 
 // StorageGetNRangeTest testing storage GetN function
-func StorageGetNRangeTest(server *Server, t *testing.T, n int) {
+func StorageGetNRangeTest(server *ooo.Server, t *testing.T, n int) {
 	server.Storage.Clear()
 	for i := 1; i < n; i++ {
 		value := strconv.Itoa(i)
@@ -1051,7 +1052,7 @@ func StorageGetNRangeTest(server *Server, t *testing.T, n int) {
 }
 
 // StorageKeysRangeTest testing storage KeysRange function
-func StorageKeysRangeTest(server *Server, t *testing.T, n int) {
+func StorageKeysRangeTest(server *ooo.Server, t *testing.T, n int) {
 	server.Storage.Clear()
 	first := ""
 	firstNow := int64(0)
@@ -1228,7 +1229,7 @@ func WatchStorageNoopTest(db storage.Database, t *testing.T) {
 	db.Clear()
 }
 
-func StorageBatchSetTest(server *Server, t *testing.T, n int) {
+func StorageBatchSetTest(server *ooo.Server, t *testing.T, n int) {
 	server.Storage.Clear()
 	testData := json.RawMessage(`{"test":"123"}`)
 	for i := 1; i < n; i++ {

--- a/oootest/stream.go
+++ b/oootest/stream.go
@@ -1,4 +1,4 @@
-package ooo
+package oootest
 
 import (
 	"encoding/json"
@@ -13,6 +13,7 @@ import (
 
 	"github.com/benitogf/jsondiff"
 	"github.com/benitogf/jsonpatch"
+	"github.com/benitogf/ooo"
 	"github.com/benitogf/ooo/client"
 	ooio "github.com/benitogf/ooo/io"
 	"github.com/benitogf/ooo/messages"
@@ -24,7 +25,7 @@ import (
 )
 
 // remoteConfig creates a RemoteConfig for the given server
-func remoteConfig(server *Server) ooio.RemoteConfig {
+func remoteConfig(server *ooo.Server) ooio.RemoteConfig {
 	return ooio.RemoteConfig{
 		Client: &http.Client{},
 		Host:   server.Address,
@@ -33,7 +34,7 @@ func remoteConfig(server *Server) ooio.RemoteConfig {
 
 // StreamBroadcastTest testing stream function
 // Note: Uses raw websocket to verify patch protocol and meta.Object structure
-func StreamBroadcastTest(t *testing.T, server *Server) {
+func StreamBroadcastTest(t *testing.T, server *ooo.Server) {
 	var wg sync.WaitGroup
 	var postIndexResponse ooio.IndexResponse
 	var wsObject meta.Object
@@ -108,7 +109,7 @@ func StreamBroadcastTest(t *testing.T, server *Server) {
 
 // StreamItemGlobBroadcastTest testing stream function
 // Note: Uses raw websocket to verify patch protocol and meta.Object structure
-func StreamItemGlobBroadcastTest(t *testing.T, server *Server) {
+func StreamItemGlobBroadcastTest(t *testing.T, server *ooo.Server) {
 	var wg sync.WaitGroup
 	var postIndexResponse ooio.IndexResponse
 	var wsObject meta.Object
@@ -184,7 +185,7 @@ func StreamItemGlobBroadcastTest(t *testing.T, server *Server) {
 
 // StreamGlobBroadcastTest testing stream function
 // Note: This test uses raw websocket to verify patch/snapshot protocol behavior
-func StreamGlobBroadcastTest(t *testing.T, server *Server, n int) {
+func StreamGlobBroadcastTest(t *testing.T, server *ooo.Server, n int) {
 	var wg sync.WaitGroup
 	var indexResponse ooio.IndexResponse
 	var wsObjects []meta.Object
@@ -302,7 +303,7 @@ func StreamGlobBroadcastTest(t *testing.T, server *Server, n int) {
 
 // StreamBroadcastFilterTest testing stream function
 // Note: This test uses raw websocket to verify snapshot/patch protocol behavior
-func StreamBroadcastFilterTest(t *testing.T, server *Server) {
+func StreamBroadcastFilterTest(t *testing.T, server *ooo.Server) {
 	var wg sync.WaitGroup
 	var wsExtraEvent messages.Message
 	var callCount int
@@ -352,7 +353,7 @@ func StreamBroadcastFilterTest(t *testing.T, server *Server) {
 
 // StreamBroadcastForcePatchTest testing stream function
 // Note: This test uses raw websocket to verify ForcePatch behavior (no snapshots after first)
-func StreamBroadcastForcePatchTest(t *testing.T, server *Server) {
+func StreamBroadcastForcePatchTest(t *testing.T, server *ooo.Server) {
 	var wg sync.WaitGroup
 	var wsExtraEvent messages.Message
 	// extra route
@@ -412,7 +413,7 @@ func StreamBroadcastForcePatchTest(t *testing.T, server *Server) {
 
 // StreamBroadcastNoPatchTest testing stream function
 // Note: This test uses raw websocket to verify NoPatch behavior (all messages are snapshots)
-func StreamBroadcastNoPatchTest(t *testing.T, server *Server) {
+func StreamBroadcastNoPatchTest(t *testing.T, server *ooo.Server) {
 	var wg sync.WaitGroup
 	var wsExtraEvent messages.Message
 	// extra route
@@ -454,7 +455,7 @@ func StreamBroadcastNoPatchTest(t *testing.T, server *Server) {
 	wg.Wait()
 }
 
-func StreamGlobBroadcastConcurrentTest(t *testing.T, server *Server, n int) {
+func StreamGlobBroadcastConcurrentTest(t *testing.T, server *ooo.Server, n int) {
 	type TestData struct {
 		SearchMetadata struct {
 			Count float64 `json:"count"`
@@ -551,7 +552,7 @@ func StreamGlobBroadcastConcurrentTest(t *testing.T, server *Server, n int) {
 	entriesLock.Unlock()
 }
 
-func StreamBroadcastPatchTest(t *testing.T, server *Server) {
+func StreamBroadcastPatchTest(t *testing.T, server *ooo.Server) {
 	var wg sync.WaitGroup
 	type TestSubField struct {
 		One   string `json:"one"`
@@ -621,7 +622,7 @@ func StreamBroadcastPatchTest(t *testing.T, server *Server) {
 // when items are inserted and broadcast to subscribed clients.
 // The client should never see more than the limit number of items due to ReadListFilter.
 // Note: This test uses raw websocket to verify patch protocol and limit enforcement
-func StreamLimitFilterTest(t *testing.T, server *Server) {
+func StreamLimitFilterTest(t *testing.T, server *ooo.Server) {
 	var wg sync.WaitGroup
 	var wsObjects []meta.Object
 	var wsEvent messages.Message
@@ -631,7 +632,7 @@ func StreamLimitFilterTest(t *testing.T, server *Server) {
 	const totalInserts = limit + 5 // Insert more than the limit
 
 	// Set up limit filter - uses ReadListFilter to limit view + AfterWrite to cleanup
-	server.LimitFilter("limited/*", LimitFilterConfig{Limit: limit})
+	server.LimitFilter("limited/*", ooo.LimitFilterConfig{Limit: limit})
 	cfg := remoteConfig(server)
 
 	// Subscribe using raw websocket
@@ -701,7 +702,7 @@ func StreamLimitFilterTest(t *testing.T, server *Server) {
 // 3. Glob delete: multiple items deleted with single broadcast returning empty list
 // 4. List sort order: newest first (descending by created)
 // 5. Nested paths: box/*/things/* pattern matching
-func ClientCompatibilityTest(t *testing.T, server *Server) {
+func ClientCompatibilityTest(t *testing.T, server *ooo.Server) {
 	cfg := remoteConfig(server)
 
 	// Test 1: Object lifecycle - verify updated field behavior

--- a/rest_test.go
+++ b/rest_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/benitogf/go-json"
 	"github.com/benitogf/ooo"
 	"github.com/benitogf/ooo/meta"
+	"github.com/benitogf/ooo/oootest"
 	"github.com/stretchr/testify/require"
 )
 
@@ -89,7 +90,7 @@ func TestRestDel(t *testing.T) {
 	server.Start("localhost:0")
 	defer server.Close(os.Interrupt)
 	_ = server.Storage.Del("test")
-	index, err := server.Storage.Set("test", ooo.TEST_DATA)
+	index, err := server.Storage.Set("test", oootest.TEST_DATA)
 	require.NoError(t, err)
 	require.Equal(t, "test", index)
 
@@ -107,10 +108,10 @@ func TestRestDel(t *testing.T) {
 	resp = w.Result()
 	require.Equal(t, http.StatusNotFound, resp.StatusCode)
 
-	index, err = server.Storage.Set("test/1", ooo.TEST_DATA)
+	index, err = server.Storage.Set("test/1", oootest.TEST_DATA)
 	require.NoError(t, err)
 	require.Equal(t, "1", index)
-	index, err = server.Storage.Set("test/2", ooo.TEST_DATA_UPDATE)
+	index, err = server.Storage.Set("test/2", oootest.TEST_DATA_UPDATE)
 	require.NoError(t, err)
 	require.Equal(t, "2", index)
 
@@ -136,10 +137,10 @@ func TestRestGet(t *testing.T) {
 	server.Storage.Clear()
 	defer server.Close(os.Interrupt)
 	_ = server.Storage.Del("test")
-	index, err := server.Storage.Set("test", ooo.TEST_DATA)
+	index, err := server.Storage.Set("test", oootest.TEST_DATA)
 	require.NoError(t, err)
 	require.Equal(t, "test", index)
-	index, err = server.Storage.Set("sources", ooo.TEST_DATA_UPDATE)
+	index, err = server.Storage.Set("sources", oootest.TEST_DATA_UPDATE)
 	require.NoError(t, err)
 	require.Equal(t, "sources", index)
 	data, _ := server.Storage.Get("test")
@@ -183,7 +184,7 @@ func TestRestStats(t *testing.T) {
 	server.Start("localhost:0")
 	defer server.Close(os.Interrupt)
 
-	index, err := server.Storage.Set("test/1", ooo.TEST_DATA)
+	index, err := server.Storage.Set("test/1", oootest.TEST_DATA)
 	require.NoError(t, err)
 	require.NotEmpty(t, index)
 
@@ -221,11 +222,11 @@ func TestRestResponseCode(t *testing.T) {
 	server.Start("localhost:0")
 	defer server.Close(os.Interrupt)
 
-	index, err := server.Storage.Set("test", ooo.TEST_DATA)
+	index, err := server.Storage.Set("test", oootest.TEST_DATA)
 	require.NoError(t, err)
 	require.NotEmpty(t, index)
 
-	index, err = server.Storage.Set("test/1", ooo.TEST_DATA_UPDATE)
+	index, err = server.Storage.Set("test/1", oootest.TEST_DATA_UPDATE)
 	require.NoError(t, err)
 	require.NotEmpty(t, index)
 


### PR DESCRIPTION
## Summary
- `streamTest.go` and `storageTest.go` declared `package ooo` (no `_test.go` suffix), so `testing`, `httptest`, `pkg/expect`, and `testify` ended up in the main binary of every consumer of `github.com/benitogf/ooo` — plus the `-test.*` flag set.
- Move the public helpers to a sibling package `github.com/benitogf/ooo/oootest`. Production consumers no longer pull those imports; tests opt in by importing the new path.

## Changes
- `streamTest.go` → `oootest/stream.go` — `package oootest`, `*Server` → `*ooo.Server`
- `storageTest.go` → `oootest/storage.go` — same
- `memory_test.go`, `memory_bench_test.go`: converted from `package ooo` to `package ooo_test`; calls now `oootest.X(...)`
- `rest_test.go` (already `package ooo_test`): `TEST_DATA` qualified to `oootest.TEST_DATA`
- `filters_test.go` must stay `package ooo` (uses unexported `server.filters`); importing oootest from there would cycle, so it uses a local `fixturePostBody` instead

## Verification
- Production binary that imports `ooo` no longer pulls `testing` / `httptest` / `testify` / `pkg/expect` (verified with `go list -deps` on a tiny consumer module — none of those packages appear).
- Full race-clean suite green: `go test -race ./...`

## Breaking change

`github.com/benitogf/ko` still references `ooo.ClientCompatibilityTest`, `ooo.StorageBeforeReadTest`, `ooo.StorageAfterWriteTest`, `ooo.WatchStorageNoopTest`. After this merges, ko's tests will fail to compile until updated to `oootest.*`. Follow-up PR will fix ko.

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)