### PR TITLE
feat(key): admit hyphen, dot, and underscore in key paths

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -195,8 +195,10 @@ func (server *Server) Endpoint(cfg EndpointConfig) {
 		vars = extractPathVars(cfg.Path)
 	}
 
-	// Register route with router
+	// Register route with router and mirror onto the route oracle so the
+	// data wildcard defers to this Endpoint regardless of registration order.
 	server.Router.HandleFunc(cfg.Path, cfg.Handler).Methods(methods...)
+	server.RegisterOracleRoute(cfg.Path, methods)
 
 	// Track for UI
 	server.endpoints = append(server.endpoints, ui.EndpointInfo{

--- a/key/key.go
+++ b/key/key.go
@@ -25,16 +25,20 @@ func HasGlob(path string) bool {
 }
 
 // isValidChar checks if a character is valid for a key path.
-// Valid characters: a-z, A-Z, 0-9, *, /
+// Valid characters: a-z, A-Z, 0-9, *, /, -, _, .
 func isValidChar(c byte) bool {
 	return (c >= 'a' && c <= 'z') ||
 		(c >= 'A' && c <= 'Z') ||
 		(c >= '0' && c <= '9') ||
-		c == '*' || c == '/'
+		c == '*' || c == '/' ||
+		c == '-' || c == '_' || c == '.'
 }
 
 // isValidEndChar checks if a character is valid for start/end of a key.
 // Valid characters: a-z, A-Z, 0-9, *
+//
+// Separators (/, -, _, .) are explicitly excluded so a key cannot start or
+// end with one — that constraint is what makes path joins unambiguous.
 func isValidEndChar(c byte) bool {
 	return (c >= 'a' && c <= 'z') ||
 		(c >= 'A' && c <= 'Z') ||
@@ -44,7 +48,7 @@ func isValidEndChar(c byte) bool {
 
 // IsValid checks that the key pattern is supported.
 // Uses string-based validation instead of regex for better performance.
-// Valid patterns: ^[a-zA-Z*\d]$|^[a-zA-Z*\d][a-zA-Z*\d/]+[a-zA-Z*\d]$
+// Valid patterns: ^[a-zA-Z*\d]$|^[a-zA-Z*\d][a-zA-Z*\d/\-_.]+[a-zA-Z*\d]$
 func IsValid(key string) bool {
 	if len(key) == 0 {
 		return false

--- a/key/key.go
+++ b/key/key.go
@@ -14,6 +14,17 @@ var (
 	ErrGlobNotAtEnd     = errors.New("key: glob pattern must be at the end of the path")
 )
 
+// PathPattern is the gorilla/mux path-variable regex matching every character
+// IsValid accepts (including the glob marker). Packages registering HTTP
+// routes that key off paths — pivot's sync routes, downstream proxies — should
+// reference this constant instead of duplicating the character class so they
+// stay aligned with the key validator.
+//
+// Example:
+//
+//	router.HandleFunc("/items/{id:"+key.PathPattern+"}", handler)
+const PathPattern = `[a-zA-Z\*\d\/\-_.]+`
+
 // IsGlob returns true if the path ends with a glob pattern (/*).
 func IsGlob(path string) bool {
 	return LastIndex(path) == "*"

--- a/key/key_test.go
+++ b/key/key_test.go
@@ -26,6 +26,35 @@ func TestKeyIsValid(t *testing.T) {
 	require.False(t, IsValid("test///1"))
 }
 
+// TestKeyIsValidWithExtendedChars asserts that hyphen, underscore and dot are
+// accepted in keys so that UUIDs, ISO dates, filenames, and snake_case
+// identifiers can be used as keys without a side mapping.
+func TestKeyIsValidWithExtendedChars(t *testing.T) {
+	require.True(t, IsValid("users/john-doe"))
+	require.True(t, IsValid("logs/2026-05-08"))
+	require.True(t, IsValid("data/report.json"))
+	require.True(t, IsValid("users/jane_doe"))
+	require.True(t, IsValid("550e8400-e29b-41d4-a716-446655440000"))
+	require.True(t, IsValid("a-b/c.d/e_f"))
+	require.True(t, IsValid("a-b/*"))
+
+	// Edge: separators may not start or end the key (consistent with /).
+	require.False(t, IsValid("-leading"))
+	require.False(t, IsValid("trailing-"))
+	require.False(t, IsValid(".leading"))
+	require.False(t, IsValid("trailing."))
+	require.False(t, IsValid("_leading"))
+	require.False(t, IsValid("trailing_"))
+
+	// Still rejected: characters that would need URL encoding or carry special
+	// meaning in JSON / paths.
+	require.False(t, IsValid("a b"))
+	require.False(t, IsValid("a:b"))
+	require.False(t, IsValid("a@b"))
+	require.False(t, IsValid("a%b"))
+	require.False(t, IsValid("a+b"))
+}
+
 func TestKeyMatch(t *testing.T) {
 	require.True(t, Match("*", "thing"))
 	require.True(t, Match("games/*", "games/*"))

--- a/memory_test.go
+++ b/memory_test.go
@@ -6,7 +6,6 @@ import (
 	"runtime"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/benitogf/go-json"
 	"github.com/benitogf/ooo/client"
@@ -29,24 +28,6 @@ func TestStorage(t *testing.T) {
 	defer app.Close(os.Interrupt)
 	StorageListTest(app, t)
 	StorageObjectTest(app, t)
-}
-
-// waitForPoolConn polls the stream state until the named pool has at least n
-// connections. Bridges a pre-existing race where Stream.New sends the initial
-// snapshot synchronously before addConnToPool, so the client can fire its
-// initial OnMessage callback before the conn is registered for broadcasts.
-func waitForPoolConn(t *testing.T, server *Server, key string, n int) {
-	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		for _, p := range server.Stream.GetState() {
-			if p.Key == key && p.Connections >= n {
-				return
-			}
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
-	t.Fatalf("pool %q never reached %d connections", key, n)
 }
 
 // TestSubscribeExtendedKeyChars asserts that a client can subscribe to keys
@@ -93,7 +74,6 @@ func TestSubscribeExtendedKeyChars(t *testing.T) {
 				},
 			})
 			wg.Wait() // initial snapshot
-			waitForPoolConn(t, server, k, 1)
 
 			wg.Add(1)
 			_, err := server.Storage.Set(k, json.RawMessage(`{"value":"set"}`))
@@ -142,7 +122,6 @@ func TestSubscribeListExtendedKeyChars(t *testing.T) {
 		},
 	})
 	wg.Wait() // initial empty snapshot
-	waitForPoolConn(t, server, "users/*", 1)
 
 	wg.Add(1)
 	_, err := server.Storage.Set("users/john-doe", json.RawMessage(`{"name":"john-doe"}`))

--- a/memory_test.go
+++ b/memory_test.go
@@ -26,6 +26,48 @@ func TestStorage(t *testing.T) {
 	StorageObjectTest(app, t)
 }
 
+// TestStorageExtendedKeyChars asserts the storage layer accepts keys with
+// hyphens, dots, and underscores so that UUIDs, ISO dates, filenames, and
+// snake_case identifiers work end-to-end through Set/Get/GetList/Del.
+func TestStorageExtendedKeyChars(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+	app := &Server{}
+	app.Silence = true
+	app.Start("localhost:0")
+	defer app.Close(os.Interrupt)
+
+	keys := []string{
+		"users/john-doe",
+		"logs/2026-05-08",
+		"data/report.json",
+		"users/jane_doe",
+		"550e8400-e29b-41d4-a716-446655440000",
+	}
+
+	for _, k := range keys {
+		_, err := app.Storage.Set(k, TEST_DATA)
+		require.NoError(t, err, "Set %q", k)
+
+		obj, err := app.Storage.Get(k)
+		require.NoError(t, err, "Get %q", k)
+		require.NotEmpty(t, obj.Data)
+	}
+
+	users, err := app.Storage.GetList("users/*")
+	require.NoError(t, err)
+	require.Len(t, users, 2)
+
+	logs, err := app.Storage.GetList("logs/*")
+	require.NoError(t, err)
+	require.Len(t, logs, 1)
+
+	for _, k := range keys {
+		require.NoError(t, app.Storage.Del(k))
+	}
+}
+
 func TestStreamBroadcast(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Parallel()

--- a/memory_test.go
+++ b/memory_test.go
@@ -1,10 +1,15 @@
 package ooo
 
 import (
+	"context"
 	"os"
 	"runtime"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/benitogf/go-json"
+	"github.com/benitogf/ooo/client"
 	"github.com/benitogf/ooo/monotonic"
 	"github.com/benitogf/ooo/storage"
 	"github.com/stretchr/testify/require"
@@ -24,6 +29,127 @@ func TestStorage(t *testing.T) {
 	defer app.Close(os.Interrupt)
 	StorageListTest(app, t)
 	StorageObjectTest(app, t)
+}
+
+// waitForPoolConn polls the stream state until the named pool has at least n
+// connections. Bridges a pre-existing race where Stream.New sends the initial
+// snapshot synchronously before addConnToPool, so the client can fire its
+// initial OnMessage callback before the conn is registered for broadcasts.
+func waitForPoolConn(t *testing.T, server *Server, key string, n int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		for _, p := range server.Stream.GetState() {
+			if p.Key == key && p.Connections >= n {
+				return
+			}
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("pool %q never reached %d connections", key, n)
+}
+
+// TestSubscribeExtendedKeyChars asserts that a client can subscribe to keys
+// containing hyphens, dots, and underscores end-to-end (initial snapshot +
+// follow-up broadcast on Set).
+func TestSubscribeExtendedKeyChars(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+	type payload struct {
+		Value string `json:"value"`
+	}
+	keys := []string{
+		"users/john-doe",
+		"logs/2026-05-09",
+		"data/report.json",
+		"users/jane_doe",
+		"550e8400-e29b-41d4-a716-446655440000",
+	}
+	for _, k := range keys {
+		t.Run(k, func(t *testing.T) {
+			server := &Server{}
+			server.Silence = true
+			server.Start("localhost:0")
+			defer server.Close(os.Interrupt)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			cfg := client.SubscribeConfig{
+				Ctx:     ctx,
+				Server:  client.Server{Protocol: "ws", Host: server.Address},
+				Silence: true,
+			}
+
+			var state payload
+			var wg sync.WaitGroup
+
+			wg.Add(1)
+			go client.Subscribe(cfg, k, client.SubscribeEvents[payload]{
+				OnMessage: func(item client.Meta[payload]) {
+					state = item.Data
+					wg.Done()
+				},
+			})
+			wg.Wait() // initial snapshot
+			waitForPoolConn(t, server, k, 1)
+
+			wg.Add(1)
+			_, err := server.Storage.Set(k, json.RawMessage(`{"value":"set"}`))
+			require.NoError(t, err)
+			wg.Wait() // post-Set broadcast
+
+			require.Equal(t, "set", state.Value)
+		})
+	}
+}
+
+// TestSubscribeListExtendedKeyChars asserts that a glob subscription over a
+// path with hyphenated child keys delivers the inserted item to the client.
+func TestSubscribeListExtendedKeyChars(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+	type payload struct {
+		Name string `json:"name"`
+	}
+	server := &Server{}
+	server.Silence = true
+	server.Start("localhost:0")
+	defer server.Close(os.Interrupt)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := client.SubscribeConfig{
+		Ctx:     ctx,
+		Server:  client.Server{Protocol: "ws", Host: server.Address},
+		Silence: true,
+	}
+
+	var seen []string
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go client.SubscribeList(cfg, "users/*", client.SubscribeListEvents[payload]{
+		OnMessage: func(items []client.Meta[payload]) {
+			seen = nil
+			for _, it := range items {
+				seen = append(seen, it.Data.Name)
+			}
+			wg.Done()
+		},
+	})
+	wg.Wait() // initial empty snapshot
+	waitForPoolConn(t, server, "users/*", 1)
+
+	wg.Add(1)
+	_, err := server.Storage.Set("users/john-doe", json.RawMessage(`{"name":"john-doe"}`))
+	require.NoError(t, err)
+	wg.Wait() // post-Set broadcast
+
+	require.Contains(t, seen, "john-doe")
 }
 
 // TestStorageExtendedKeyChars asserts the storage layer accepts keys with

--- a/ooo.go
+++ b/ooo.go
@@ -654,14 +654,15 @@ func (server *Server) setupRoutes() {
 	// router that mirrors those registrations and tells the wildcard to
 	// step aside when the request matches an explicit route.
 	skip := mux.MatcherFunc(server.routeOracleSkip)
-	server.Router.Handle("/{key:[a-zA-Z\\*\\d\\/\\-_.]+}", http.TimeoutHandler(
+	keyPath := "/{key:" + key.PathPattern + "}"
+	server.Router.Handle(keyPath, http.TimeoutHandler(
 		http.HandlerFunc(server.unpublish), server.Deadline, deadlineMsg)).Methods("DELETE").MatcherFunc(skip)
-	server.Router.Handle("/{key:[a-zA-Z\\*\\d\\/\\-_.]+}", http.TimeoutHandler(
+	server.Router.Handle(keyPath, http.TimeoutHandler(
 		http.HandlerFunc(server.publish), server.Deadline, deadlineMsg)).Methods("POST").MatcherFunc(skip)
-	server.Router.Handle("/{key:[a-zA-Z\\*\\d\\/\\-_.]+}", http.TimeoutHandler(
+	server.Router.Handle(keyPath, http.TimeoutHandler(
 		http.HandlerFunc(server.patch), server.Deadline, deadlineMsg)).Methods("PATCH").MatcherFunc(skip)
-	server.Router.HandleFunc("/{key:[a-zA-Z\\*\\d\\/\\-_.]+}", server.read).Methods("GET").MatcherFunc(skip)
-	server.Router.HandleFunc("/{key:[a-zA-Z\\*\\d\\/\\-_.]+}", server.read).Queries("v", "{[\\d]}").Methods("GET").MatcherFunc(skip)
+	server.Router.HandleFunc(keyPath, server.read).Methods("GET").MatcherFunc(skip)
+	server.Router.HandleFunc(keyPath, server.read).Queries("v", "{[\\d]}").Methods("GET").MatcherFunc(skip)
 }
 
 // routeOracleSkip returns true if the request does NOT match any registered

--- a/ooo.go
+++ b/ooo.go
@@ -114,6 +114,8 @@ type Server struct {
 	limitFilters       map[string]*limitFilterReg // tracks limit filter registrations
 	endpoints          []ui.EndpointInfo          // registered custom endpoints
 	proxies            []ui.ProxyInfo             // registered proxy routes
+	routeOracle        *mux.Router                // mirrors Endpoint/Proxy paths so the data wildcard can defer to them
+	routeOracleMu      sync.Mutex                 // serializes oracle registrations and matches
 	proxyCleanups      []func()                   // cleanup functions for proxy subscriptions
 	proxyCleanupMu     sync.Mutex                 // protects proxyCleanups
 	NoBroadcastKeys    []string
@@ -578,6 +580,9 @@ func (server *Server) defaults() {
 	if server.Router == nil {
 		server.Router = mux.NewRouter()
 	}
+	if server.routeOracle == nil {
+		server.routeOracle = mux.NewRouter()
+	}
 	if server.Console == nil {
 		server.Console = coat.NewConsole(server.Address, server.Silence)
 	}
@@ -641,15 +646,51 @@ func (server *Server) setupRoutes() {
 			server.Router.Handle("/"+path, explorerHandler).Methods("GET")
 		}
 	}
-	// https://www.calhoun.io/why-cant-i-pass-this-function-as-an-http-handler/
-	server.Router.Handle("/{key:[a-zA-Z\\*\\d\\/]+}", http.TimeoutHandler(
-		http.HandlerFunc(server.unpublish), server.Deadline, deadlineMsg)).Methods("DELETE")
-	server.Router.Handle("/{key:[a-zA-Z\\*\\d\\/]+}", http.TimeoutHandler(
-		http.HandlerFunc(server.publish), server.Deadline, deadlineMsg)).Methods("POST")
-	server.Router.Handle("/{key:[a-zA-Z\\*\\d\\/]+}", http.TimeoutHandler(
-		http.HandlerFunc(server.patch), server.Deadline, deadlineMsg)).Methods("PATCH")
-	server.Router.HandleFunc("/{key:[a-zA-Z\\*\\d\\/]+}", server.read).Methods("GET")
-	server.Router.HandleFunc("/{key:[a-zA-Z\\*\\d\\/]+}", server.read).Queries("v", "{[\\d]}").Methods("GET")
+	// The data wildcard accepts the same character class as key.IsValid so
+	// that hyphenated/dotted/underscored keys (UUIDs, ISO dates, filenames,
+	// snake_case identifiers) are addressable via REST and ws subscriptions.
+	// Custom Endpoint and Proxy paths registered via server.Endpoint() /
+	// proxy.Register() take precedence: routeOracleSkip checks the oracle
+	// router that mirrors those registrations and tells the wildcard to
+	// step aside when the request matches an explicit route.
+	skip := mux.MatcherFunc(server.routeOracleSkip)
+	server.Router.Handle("/{key:[a-zA-Z\\*\\d\\/\\-_.]+}", http.TimeoutHandler(
+		http.HandlerFunc(server.unpublish), server.Deadline, deadlineMsg)).Methods("DELETE").MatcherFunc(skip)
+	server.Router.Handle("/{key:[a-zA-Z\\*\\d\\/\\-_.]+}", http.TimeoutHandler(
+		http.HandlerFunc(server.publish), server.Deadline, deadlineMsg)).Methods("POST").MatcherFunc(skip)
+	server.Router.Handle("/{key:[a-zA-Z\\*\\d\\/\\-_.]+}", http.TimeoutHandler(
+		http.HandlerFunc(server.patch), server.Deadline, deadlineMsg)).Methods("PATCH").MatcherFunc(skip)
+	server.Router.HandleFunc("/{key:[a-zA-Z\\*\\d\\/\\-_.]+}", server.read).Methods("GET").MatcherFunc(skip)
+	server.Router.HandleFunc("/{key:[a-zA-Z\\*\\d\\/\\-_.]+}", server.read).Queries("v", "{[\\d]}").Methods("GET").MatcherFunc(skip)
+}
+
+// routeOracleSkip returns true if the request does NOT match any registered
+// Endpoint or Proxy route. It is wired as a MatcherFunc on the data wildcard
+// so explicit routes take precedence regardless of registration order.
+func (server *Server) routeOracleSkip(r *http.Request, _ *mux.RouteMatch) bool {
+	server.routeOracleMu.Lock()
+	defer server.routeOracleMu.Unlock()
+	if server.routeOracle == nil {
+		return true
+	}
+	var m mux.RouteMatch
+	return !server.routeOracle.Match(r, &m)
+}
+
+// RegisterOracleRoute mirrors a path registration onto the oracle router so
+// the data wildcard can defer to it. Method-restricted routes pass methods;
+// pass nil for any-method routes (proxies). Endpoint() and the proxy package
+// call this after registering on Server.Router.
+func (server *Server) RegisterOracleRoute(path string, methods []string) {
+	server.routeOracleMu.Lock()
+	defer server.routeOracleMu.Unlock()
+	if server.routeOracle == nil {
+		server.routeOracle = mux.NewRouter()
+	}
+	route := server.routeOracle.HandleFunc(path, func(http.ResponseWriter, *http.Request) {})
+	if len(methods) > 0 {
+		route.Methods(methods...)
+	}
 }
 
 // StartWithError initializes and starts the http server and database connection.

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -484,8 +484,10 @@ func Route(server *ooo.Server, localPath string, cfg Config) error {
 	// Convert glob pattern to mux pattern
 	muxPattern := GlobToMuxPattern(localPath)
 
-	// Register the route
+	// Register the route and mirror onto the route oracle so the data
+	// wildcard defers to this proxy regardless of registration order.
 	server.Router.HandleFunc("/"+muxPattern, handler)
+	server.RegisterOracleRoute("/"+muxPattern, nil)
 
 	// Register for UI visibility
 	server.RegisterProxy(ui.ProxyInfo{
@@ -571,9 +573,13 @@ func RouteList(server *ooo.Server, localPath string, cfg Config) error {
 	// Convert glob pattern to mux pattern
 	muxPattern := GlobToMuxPattern(localPath)
 
-	// Register routes - specific path first, then base
+	// Register routes - specific path first, then base. Mirror both onto
+	// the route oracle so the data wildcard defers to them regardless of
+	// registration order.
 	server.Router.HandleFunc("/"+muxPattern, itemHandler)
 	server.Router.HandleFunc("/"+basePath, listHandler)
+	server.RegisterOracleRoute("/"+muxPattern, nil)
+	server.RegisterOracleRoute("/"+basePath, nil)
 
 	// Register for UI visibility
 	server.RegisterProxy(ui.ProxyInfo{
@@ -809,6 +815,7 @@ func RouteWithVars(server *ooo.Server, localPath string, cfg Config) error {
 	}
 
 	server.Router.HandleFunc("/"+localPath, handler)
+	server.RegisterOracleRoute("/"+localPath, nil)
 
 	// Register for UI visibility
 	server.RegisterProxy(ui.ProxyInfo{

--- a/stream/clock.go
+++ b/stream/clock.go
@@ -9,11 +9,19 @@ import (
 // BroadcastClock sends time to all the subscribers
 func (sm *Stream) BroadcastClock(data string) {
 	sm.mutex.RLock()
-	defer sm.mutex.RUnlock()
-	if sm.clockPool == nil {
+	pool := sm.clockPool
+	sm.mutex.RUnlock()
+	if pool == nil {
 		return
 	}
-	connections := sm.clockPool.connections
+
+	// Snapshot the connection slice under pool.mutex so a concurrent
+	// attachConn/Close cannot mutate it while we iterate. Writing happens
+	// outside the lock so a slow client cannot stall subscribers/teardown.
+	pool.mutex.RLock()
+	connections := make([]*Conn, len(pool.connections))
+	copy(connections, pool.connections)
+	pool.mutex.RUnlock()
 
 	for _, client := range connections {
 		sm.WriteClock(client, data)

--- a/stream/patch.go
+++ b/stream/patch.go
@@ -44,6 +44,14 @@ func isGlobKey(key string) bool {
 	return strings.Contains(key, "*")
 }
 
+// isNoopJSONPatch reports whether a marshaled JSON patch contains no
+// operations. json.Marshal renders an empty operations slice as "[]" and a
+// nil slice as "null"; both are valid representations of a no-op patch.
+func isNoopJSONPatch(patch []byte) bool {
+	s := strings.TrimSpace(string(patch))
+	return s == "[]" || s == "null"
+}
+
 // ProcessBroadcast processes a broadcast event and returns the message to send.
 // It updates the cache and generates the appropriate patch or snapshot.
 // noPatch forces snapshot mode (no patches).
@@ -201,6 +209,16 @@ func processObjectBroadcast(cache *Cache, poolKey string, operation string, obj 
 		if snapshot || patch == nil {
 			return BroadcastResult{Data: data, Snapshot: true}
 		}
+		// An empty JSON patch ("[]" or "null") means the new state equals the
+		// cached one and there is nothing for the subscriber to apply. This
+		// happens when a watcher event queued before the subscriber attaches
+		// is dequeued after fetch() already incorporated its state; without
+		// the skip, the subscriber's first post-snapshot message is a no-op
+		// patch instead of the real next update, and tests reading "next
+		// message" see the stale echo.
+		if isNoopJSONPatch(patch) {
+			return BroadcastResult{Skip: true}
+		}
 		return BroadcastResult{Data: patch, Snapshot: false}
 
 	case "del":
@@ -215,6 +233,9 @@ func processObjectBroadcast(cache *Cache, poolKey string, operation string, obj 
 		patch, snapshot := generateObjectPatch(oldObj, &empty)
 		if snapshot || patch == nil {
 			return BroadcastResult{Data: meta.EmptyObject, Snapshot: true}
+		}
+		if isNoopJSONPatch(patch) {
+			return BroadcastResult{Skip: true}
 		}
 		return BroadcastResult{Data: patch, Snapshot: false}
 	}

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -166,22 +166,70 @@ func (sm *Stream) New(key string, w http.ResponseWriter, r *http.Request, data [
 		mutex: sync.Mutex{},
 	}
 
-	// Send initial snapshot BEFORE adding to pool
+	// Send the initial snapshot and add the conn to its pool atomically
+	// under pool.mutex. Holding the pool lock across both steps means any
+	// concurrent broadcast either runs before the snapshot is sent (and
+	// finds 0 conns, so it cannot deliver an event the client hasn't yet
+	// established baseline for) or runs after the conn is registered (and
+	// reaches the conn). Without this, the client could read its snapshot,
+	// trigger a Set, and have the resulting broadcast iterate the pool
+	// before addConnToPool completed — silently losing the event.
+	if err := sm.attachConn(key, client, data, version); err != nil {
+		return nil, err
+	}
+	return client, nil
+}
+
+// attachConn locates (or creates) the pool for key, then under pool.mutex
+// sends the initial snapshot (if any) and appends the conn to
+// pool.connections. The combination is the subscribe-side counterpart of
+// Broadcast's per-pool critical section: a broadcast cannot run between
+// "snapshot sent" and "conn registered".
+func (sm *Stream) attachConn(key string, client *Conn, data []byte, version int64) error {
+	pool := sm.getOrCreatePool(key)
+	pool.mutex.Lock()
+	defer pool.mutex.Unlock()
+
 	if data != nil {
 		client.mutex.Lock()
 		client.conn.SetWriteDeadline(time.Now().Add(sm.WriteTimeout))
-		err = client.conn.WriteMessage(websocket.BinaryMessage, buildMessage(data, true, version))
+		err := client.conn.WriteMessage(websocket.BinaryMessage, buildMessage(data, true, version))
 		client.mutex.Unlock()
 		if err != nil {
 			client.conn.Close()
 			// Wrap with ErrHijacked since connection was already upgraded
-			return nil, errors.Join(ErrHijacked, err)
+			return errors.Join(ErrHijacked, err)
 		}
 	}
 
-	// Now add to pool - broadcasts can now reach this client
-	sm.addConnToPool(key, client)
-	return client, nil
+	pool.connections = append(pool.connections, client)
+	if key == "" {
+		sm.Console.Log("stream:connections[clock]: ", len(pool.connections))
+	} else {
+		sm.Console.Log("stream:connections["+key+"]: ", len(pool.connections))
+	}
+	return nil
+}
+
+// getOrCreatePool returns the pool for key, creating it if absent. Used by
+// attachConn so the new pool registration is committed under sm.mutex before
+// pool.mutex is taken in the caller.
+func (sm *Stream) getOrCreatePool(key string) *Pool {
+	sm.mutex.Lock()
+	defer sm.mutex.Unlock()
+	if key == "" {
+		if sm.clockPool == nil {
+			sm.clockPool = &Pool{Key: ""}
+		}
+		return sm.clockPool
+	}
+	pool := sm.getPool(key)
+	if pool == nil {
+		pool = &Pool{Key: key, connections: []*Conn{}}
+		sm.pools[key] = pool
+		sm.poolIndex.insert(key, pool)
+	}
+	return pool
 }
 
 // addConnToPool adds an existing connection to the appropriate pool


### PR DESCRIPTION
## Summary
Lets keys contain hyphens, dots, and underscores so that UUIDs, ISO dates, filenames, and snake_case identifiers can be used directly without a side mapping. Works end-to-end: storage, in-process `io.*` helpers, REST, and WebSocket subscriptions (single + glob list).

## Behaviour change
- `key.IsValid` admits `-`, `_`, and `.` as middle characters. Start/end characters are unchanged: a key still cannot start or end with a separator (`/`, `-`, `_`, `.`).
- The data wildcard route accepts the same character class so REST and ws subscriptions reach those keys. `key.PathPattern` is exported as the single source of truth — packages that wire HTTP routes off keys (pivot's sync routes, downstream proxies) reference it instead of duplicating the regex.
- Custom `Endpoint` and `Proxy` paths take precedence regardless of registration order. Each registration mirrors onto a private oracle router; the data wildcard runs a `MatcherFunc` that defers to the oracle.

## Race fixes
Closing two pre-existing subscribe/broadcast races that the new subscription tests exposed (and which sporadically flaked existing tests too):

- `Stream.New` now sends the initial snapshot and attaches the conn to its pool atomically under `pool.mutex`. Before, a client could read its snapshot, trigger a Set, and have the resulting broadcast iterate the pool before `addConnToPool` completed — the event was silently lost.
- Object broadcasts no longer emit empty JSON patches. They happened when a watcher event queued before the subscriber attached was dequeued after `fetch()` had already incorporated its state; the subscriber's "next message" became a no-op patch instead of the real next update.
- `BroadcastClock` now snapshots `clockPool.connections` under the pool's own mutex (was reading without it, relying on outer-mutex serialization that the new attach path no longer provides).

## Test plan
- [x] `key.IsValid` unit test covers hyphens, dots, underscores, UUID-shaped keys, and the start/end-separator boundary.
- [x] Storage-level integration test exercises `Set` / `Get` / `GetList` (glob) / `Del` end-to-end across the new characters.
- [x] Subscription tests cover single-object and glob-list subscriptions over keys containing each new character.
- [x] `TestServerCloseShutdownBoundedByDeadline` and the other Endpoint-after-Start tests still pass, confirming the oracle precedence shim works.
- [x] 3500-iteration race flaky-check on the full suite is clean (stopped early under the agreed protocol).

Closes #72

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)