### PR TITLE
fix(storage): serialize Layered glob deletes against individual writes

### DIFF
--- a/storage/layered.go
+++ b/storage/layered.go
@@ -34,6 +34,7 @@ type Layered struct {
 
 	mutex           sync.RWMutex
 	memMutex        sync.Map
+	writeMutex      sync.RWMutex // serializes glob deletes against individual writes
 	noBroadcastKeys []string
 	watcher         *ShardedChan
 	active          bool
@@ -223,6 +224,8 @@ func (l *Layered) SetAndUnlock(path string, data json.RawMessage) (string, error
 	if len(data) == 0 {
 		return path, ErrInvalidStorageData
 	}
+	l.writeMutex.RLock()
+	defer l.writeMutex.RUnlock()
 	return l.setLocked(path, data)
 }
 
@@ -426,6 +429,8 @@ func (l *Layered) Set(path string, data json.RawMessage) (string, error) {
 		return path, ErrGlobNotAllowed
 	}
 
+	l.writeMutex.RLock()
+	defer l.writeMutex.RUnlock()
 	lock := l._getLock(path)
 	lock.Lock()
 	defer lock.Unlock()
@@ -582,6 +587,8 @@ func (l *Layered) Push(path string, data json.RawMessage) (string, error) {
 		Data:    data,
 	}
 
+	l.writeMutex.RLock()
+	defer l.writeMutex.RUnlock()
 	lock := l._getLock(newPath)
 	lock.Lock()
 	defer lock.Unlock()
@@ -615,6 +622,8 @@ func (l *Layered) SetWithMeta(path string, data json.RawMessage, created, update
 		Data:    data,
 	}
 
+	l.writeMutex.RLock()
+	defer l.writeMutex.RUnlock()
 	lock := l._getLock(path)
 	lock.Lock()
 	defer lock.Unlock()
@@ -639,6 +648,8 @@ func (l *Layered) Del(path string) error {
 		return l.delGlob(path)
 	}
 
+	l.writeMutex.RLock()
+	defer l.writeMutex.RUnlock()
 	lock := l._getLock(path)
 	lock.Lock()
 	defer lock.Unlock()
@@ -664,9 +675,13 @@ func (l *Layered) Del(path string) error {
 }
 
 // delGlob deletes all keys matching a glob pattern across all layers.
-// Per-key locking is not applied because the glob doesn't resolve to a single
-// key; the underlying layers handle their own internal locking for glob deletes.
+// Takes writeMutex.Lock exclusively so no Set/Push/SetWithMeta/Del can
+// commit between the memory and embedded halves of the delete — a per-key
+// mutex cannot protect this, because the glob may match keys that don't
+// exist at snapshot time and could be created concurrently.
 func (l *Layered) delGlob(path string) error {
+	l.writeMutex.Lock()
+	defer l.writeMutex.Unlock()
 	if err := l.deleteGlobBothLayers(path); err != nil {
 		return err
 	}
@@ -684,9 +699,13 @@ func (l *Layered) delGlob(path string) error {
 // DelSilent deletes a key from all layers without broadcasting
 func (l *Layered) DelSilent(path string) error {
 	if key.HasGlob(path) {
+		l.writeMutex.Lock()
+		defer l.writeMutex.Unlock()
 		return l.deleteGlobBothLayers(path)
 	}
 
+	l.writeMutex.RLock()
+	defer l.writeMutex.RUnlock()
 	lock := l._getLock(path)
 	lock.Lock()
 	defer lock.Unlock()

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1003,6 +1003,125 @@ func TestLayeredDelSilentGlobRollsBackOnEmbeddedFailure(t *testing.T) {
 	require.Len(t, items, 2, "rejected DelSilent glob must leave both keys visible in memory")
 }
 
+// syncEmbedded wraps a MemoryLayer and lets a test pause embedded.Del between
+// "Del started" and "Del executed" so a concurrent Set can race with the
+// in-progress glob delete deterministically.
+type syncEmbedded struct {
+	inner      *MemoryLayer
+	delStarted chan struct{}
+	delResume  chan struct{}
+}
+
+func (s *syncEmbedded) Active() bool                      { return s.inner.Active() }
+func (s *syncEmbedded) Start(o LayerOptions) error        { return s.inner.Start(o) }
+func (s *syncEmbedded) Close()                            { s.inner.Close() }
+func (s *syncEmbedded) Get(k string) (meta.Object, error) { return s.inner.Get(k) }
+func (s *syncEmbedded) GetList(p string) ([]meta.Object, error) {
+	return s.inner.GetList(p)
+}
+func (s *syncEmbedded) Set(k string, o *meta.Object) error { return s.inner.Set(k, o) }
+func (s *syncEmbedded) Del(k string) error {
+	if s.delStarted != nil {
+		select {
+		case s.delStarted <- struct{}{}:
+		default:
+		}
+	}
+	if s.delResume != nil {
+		<-s.delResume
+	}
+	return s.inner.Del(k)
+}
+func (s *syncEmbedded) Keys() ([]string, error) { return s.inner.Keys() }
+func (s *syncEmbedded) Clear()                  { s.inner.Clear() }
+func (s *syncEmbedded) Load() (map[string]*meta.Object, error) {
+	keys, err := s.inner.Keys()
+	if err != nil {
+		return nil, err
+	}
+	data := make(map[string]*meta.Object, len(keys))
+	for _, k := range keys {
+		obj, err := s.inner.Get(k)
+		if err != nil {
+			continue
+		}
+		data[k] = &obj
+	}
+	return data, nil
+}
+
+// TestLayeredDelGlobSerializesWithConcurrentSet reproduces the race the audit
+// flagged: a Set that commits between the memory and embedded halves of a
+// glob delete used to leave the layers diverged. The fix serializes
+// individual writes against glob deletes via a write-side RWMutex — Del(glob)
+// takes the exclusive lock, Set takes the shared one — so the Set can no
+// longer interleave with the in-progress delete and both layers end up
+// agreeing on whether the key exists.
+func TestLayeredDelGlobSerializesWithConcurrentSet(t *testing.T) {
+	t.Parallel()
+
+	delStarted := make(chan struct{}, 1)
+	delResume := make(chan struct{})
+	embedded := &syncEmbedded{
+		inner:      NewMemoryLayer(),
+		delStarted: delStarted,
+		delResume:  delResume,
+	}
+	s := New(LayeredConfig{Memory: NewMemoryLayer(), Embedded: embedded})
+	require.NoError(t, s.Start(Options{NoBroadcastKeys: []string{"items/a", "items/*"}}))
+	defer s.Close()
+
+	// Drain watcher events so Set/Del don't block on a 5s send timeout.
+	sharded := s.WatchSharded()
+	for i := range sharded.Count() {
+		shard := sharded.Shard(i)
+		go func() {
+			for range shard {
+			}
+		}()
+	}
+
+	// Start a glob delete. It enters embedded.Del and blocks.
+	delDone := make(chan error, 1)
+	go func() {
+		delDone <- s.Del("items/*")
+	}()
+	<-delStarted
+
+	// Attempt a Set while the delete is mid-flight. With the fix, Set must
+	// not commit until the glob delete releases its exclusive lock.
+	setStarted := make(chan struct{})
+	setDone := make(chan error, 1)
+	go func() {
+		close(setStarted)
+		_, err := s.Set("items/a", json.RawMessage(`{"v":1}`))
+		setDone <- err
+	}()
+	<-setStarted
+
+	// Set must be blocked: it should not finish while Del is still paused.
+	select {
+	case err := <-setDone:
+		t.Fatalf("Set must wait for Del(glob): unexpected early completion err=%v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(delResume)
+	require.NoError(t, <-delDone)
+	require.NoError(t, <-setDone)
+
+	// After both finish: layers must agree.
+	memItems, err := s.GetList("items/*")
+	require.NoError(t, err)
+	embKeys, err := embedded.inner.Keys()
+	require.NoError(t, err)
+
+	memHas := len(memItems) > 0
+	embHas := len(embKeys) > 0
+	require.Equal(t, memHas, embHas,
+		"layers diverged: memory has key=%v, embedded has key=%v", memHas, embHas)
+}
+
 // TestLayeredPushReturnsEmbeddedError is the Push variant.
 func TestLayeredPushReturnsEmbeddedError(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary
Serializes Layered glob deletes against individual writes so the two storage layers cannot diverge when a `Set` / `Push` / `SetWithMeta` / `Del`-single-key overlaps with an in-flight `Del`-glob or `DelSilent`-glob. The mirror contract — memory matches the durable layer after every operation — holds for every interleaving.

## Behaviour
A per-Layered `sync.RWMutex` write barrier:
- Individual writes (`Set`, `Push`, `SetWithMeta`, `SetAndUnlock`, `Del`-non-glob) take `RLock` — multiple concurrent individual writes still proceed without serializing against each other.
- Glob deletes (`Del`-glob, `DelSilent`-glob) take `Lock` — exclusive against all writes for the duration of the delete, so no individual write can land between the memory and embedded halves.

Per-key `_getLock` is still acquired by individual writes (writers don't serialize on each other unless they target the same key). Lock order across every entry: write barrier first, then per-key lock.

## Scope notes (from self-review)
- Read paths (`Get`, `GetList`) are not covered by the write barrier. A reader during a glob delete can still observe the in-flight state. That's a different consistency question (read coherency) from the write/write race this PR fixes; left for a separate issue.
- The new `syncEmbedded` test helper duplicates the existing `mockEmbeddedLayer` mock except for a single pause hook in `Del`. Consolidation is cosmetic and left for a separate refactor.
- The barrier is global per `Layered`, not per-prefix-shard. Glob deletes are assumed rare; if they become hot, a sharded barrier would be the next step.

## Test plan
- [x] New `TestLayeredDelGlobSerializesWithConcurrentSet` deterministically pauses inside the embedded `Del` via a custom `syncEmbedded` mock, attempts a `Set` on a matching key, asserts the Set cannot complete inside a 50 ms window, then asserts the layers agree once both finish.
- [x] Existing Layered tests (rollback, mirror-invariant, error propagation, close-race) unchanged and still pass.
- [x] Full race suite green.

Closes #78

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)