### PR TITLE
fix(storage): expose ShardedChan drops via counter + callback

### DIFF
--- a/ooo.go
+++ b/ooo.go
@@ -150,10 +150,12 @@ type Server struct {
 	IdleTimeout        time.Duration
 	OnStorageEvent     storage.EventCallback
 	OnWatchPanic       func(ev storage.Event, r any) // optional: invoked on each recovered watch-goroutine panic with the offending event
+	OnDroppedEvent     func(ev storage.Event)        // optional: invoked when the sharded watcher channel drops an event after timing out
 	BeforeRead         func(key string)
 	GetPivotInfo       func() *ui.PivotInfo // Optional: returns pivot status for UI
 	NoCompress         bool                 // Disable gzip compression (useful for tests)
 	WatchPanics        int64                // Atomic counter of panics recovered in watch goroutines
+	DroppedEvents      int64                // Atomic counter of events dropped by the sharded watcher on send timeout
 	startErr           chan error           // channel for startup errors
 	clockStop          chan struct{}        // channel to signal clock goroutine to stop
 }
@@ -190,6 +192,7 @@ func (server *Server) getServerInfo() ui.ServerInfo {
 		Workers:           server.Workers,
 		Tick:              server.Tick,
 		WatchPanics:       atomic.LoadInt64(&server.WatchPanics),
+		DroppedEvents:     atomic.LoadInt64(&server.DroppedEvents),
 	}
 }
 
@@ -373,7 +376,8 @@ func (server *Server) waitStart() error {
 
 	// Start workers for sharded watcher (per-key ordering)
 	shardedWatcher := server.Storage.WatchSharded()
-	for i := 0; i < shardedWatcher.Count(); i++ {
+	shardedWatcher.SetOnDrop(server.handleDroppedEvent)
+	for i := range shardedWatcher.Count() {
 		server.watchWg.Add(1)
 		go server.watch(shardedWatcher.Shard(i))
 	}
@@ -456,6 +460,20 @@ func (server *Server) watch(sc storage.StorageChan) {
 		if !server.Storage.Active() {
 			break
 		}
+	}
+}
+
+// handleDroppedEvent runs on the storage layer's sender goroutine each time
+// the sharded watcher channel drops an event after exhausting its send
+// timeout. The dropped event has been durably committed but no subscriber
+// will ever see it — operators monitor DroppedEvents to detect a stuck or
+// slow watcher consumer.
+func (server *Server) handleDroppedEvent(ev storage.Event) {
+	atomic.AddInt64(&server.DroppedEvents, 1)
+	server.Console.Err(fmt.Sprintf("watch:dropped key=%q op=%q total=%d (consumer stuck or slow; subscribers will not see this event)",
+		ev.Key, ev.Operation, atomic.LoadInt64(&server.DroppedEvents)))
+	if server.OnDroppedEvent != nil {
+		server.OnDroppedEvent(ev)
 	}
 }
 

--- a/ooo_test.go
+++ b/ooo_test.go
@@ -458,3 +458,67 @@ func TestOnWatchPanicReceivesOffendingEvent(t *testing.T) {
 
 	require.Equal(t, int64(1), atomic.LoadInt64(&server.WatchPanics))
 }
+
+// TestOnDroppedEventReceivesOffendingEvent asserts the Server-level
+// observability hook fires when the sharded watcher drops an event after its
+// send timeout, and that DroppedEvents counts the drop. Pre-fix a stuck
+// watcher silently lost writes from subscribers' point of view, with only a
+// log line as evidence.
+func TestOnDroppedEventReceivesOffendingEvent(t *testing.T) {
+	dropped := make(chan storage.Event, 4)
+
+	server := &Server{
+		Silence: true,
+		Workers: 1,
+	}
+	// Block the worker so the shard buffer can saturate. `firstSeen` confirms
+	// the worker actually dequeued the first event before the fill loop
+	// starts — without that signal, the buffer math depends on goroutine
+	// scheduling and the test would bump DroppedEvents to 2 or block on the
+	// default 5 s Send timeout when the worker is slow to start.
+	hold := make(chan struct{})
+	firstSeen := make(chan struct{})
+	var firstOnce sync.Once
+	server.OnStorageEvent = func(ev storage.Event) {
+		firstOnce.Do(func() { close(firstSeen) })
+		<-hold
+	}
+	server.OnDroppedEvent = func(ev storage.Event) {
+		select {
+		case dropped <- ev:
+		default:
+		}
+	}
+
+	server.Start("localhost:0")
+	defer func() {
+		close(hold)
+		server.Close(os.Interrupt)
+	}()
+
+	_, err := server.Storage.Set("first", json.RawMessage(`{"v":1}`))
+	require.NoError(t, err)
+	<-firstSeen
+
+	// Saturate the shard buffer: the channel holds 100 events, and the worker
+	// is blocked draining the first.
+	for i := range 100 {
+		_, err := server.Storage.Set(fmt.Sprintf("fill-%d", i), json.RawMessage(`{"v":1}`))
+		require.NoError(t, err)
+	}
+	// Override the default 5 s send timeout via a short-timeout direct send so
+	// the test does not wait that long.
+	shardedWatcher := server.Storage.WatchSharded()
+	require.False(t,
+		shardedWatcher.SendWithTimeout(storage.Event{Key: "dropped", Operation: "set"}, 50*time.Millisecond),
+		"event should have been dropped after timing out on a saturated shard",
+	)
+
+	select {
+	case ev := <-dropped:
+		require.Equal(t, "dropped", ev.Key)
+	case <-time.After(2 * time.Second):
+		t.Fatal("OnDroppedEvent was not invoked")
+	}
+	require.Equal(t, int64(1), atomic.LoadInt64(&server.DroppedEvents))
+}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"hash/fnv"
 	"log"
+	"sync/atomic"
 	"time"
 
 	"github.com/benitogf/go-json"
@@ -48,8 +49,10 @@ type Options struct {
 
 // ShardedChan manages multiple channels for per-key ordering.
 type ShardedChan struct {
-	shards []StorageChan
-	count  int
+	shards  []StorageChan
+	count   int
+	dropped atomic.Int64
+	onDrop  atomic.Pointer[func(Event)]
 }
 
 // NewShardedChan creates a new sharded storage channel with the given number of shards.
@@ -67,6 +70,24 @@ func NewShardedChan(shardCount int) *ShardedChan {
 	}
 }
 
+// Dropped returns the total number of events the sharded channel has dropped
+// after exhausting its send timeout. Operators monitor this to detect a stuck
+// or slow watcher consumer that's silently desyncing subscribers from storage.
+func (s *ShardedChan) Dropped() int64 {
+	return s.dropped.Load()
+}
+
+// SetOnDrop installs (or clears) a callback invoked for each event that
+// SendWithTimeout drops on timeout. The callback runs synchronously on the
+// sender's goroutine — keep it cheap. Pass nil to unset.
+func (s *ShardedChan) SetOnDrop(fn func(Event)) {
+	if fn == nil {
+		s.onDrop.Store(nil)
+		return
+	}
+	s.onDrop.Store(&fn)
+}
+
 // SEND_TIMEOUT is the maximum time to wait when sending an event to a shard channel.
 // If the consumer goroutine is stuck or dead, the send will time out and the event
 // will be dropped with a log warning, preventing permanent write hangs.
@@ -74,12 +95,21 @@ const SEND_TIMEOUT = 5 * time.Second
 
 // SendWithTimeout attempts to send an event to the appropriate shard channel
 // within the given timeout. Returns true if sent, false if timed out.
+//
+// On timeout the event is dropped, the dropped counter is incremented, and
+// any installed OnDrop callback is invoked synchronously. The drop is now
+// programmatically observable instead of leaving only a log line for
+// operators to grep.
 func (s *ShardedChan) SendWithTimeout(event Event, timeout time.Duration) bool {
 	shard := s.ShardFor(event.Key)
 	select {
 	case s.shards[shard] <- event:
 		return true
 	case <-time.After(timeout):
+		s.dropped.Add(1)
+		if ptr := s.onDrop.Load(); ptr != nil {
+			(*ptr)(event)
+		}
 		log.Printf("storage: send timeout on shard %d for key %q (consumer stuck or dead), event dropped", shard, event.Key)
 		return false
 	}

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1122,6 +1122,57 @@ func TestLayeredDelGlobSerializesWithConcurrentSet(t *testing.T) {
 		"layers diverged: memory has key=%v, embedded has key=%v", memHas, embHas)
 }
 
+// TestShardedChanDropIsObservable asserts that a send-timeout drop exposes
+// both a counter and (when set) an OnDrop callback. Pre-fix the drop only
+// logged — a stuck or recovered watcher silently desynced subscribers from
+// storage with no programmatic signal for operators to monitor.
+func TestShardedChanDropIsObservable(t *testing.T) {
+	t.Parallel()
+
+	sc := NewShardedChan(1)
+	var dropped []Event
+	var mu sync.Mutex
+	sc.SetOnDrop(func(ev Event) {
+		mu.Lock()
+		dropped = append(dropped, ev)
+		mu.Unlock()
+	})
+
+	// Fill the shard buffer (capacity 100 internally).
+	for i := range 100 {
+		require.True(t, sc.SendWithTimeout(Event{Key: fmt.Sprintf("ok-%d", i)}, time.Second))
+	}
+
+	// One more send with a tiny timeout: no consumer is reading, so it drops.
+	sent := sc.SendWithTimeout(Event{Key: "drop-me"}, 10*time.Millisecond)
+	require.False(t, sent, "send must time out when the shard buffer is saturated")
+
+	require.Equal(t, int64(1), sc.Dropped(), "Dropped() must surface the drop")
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, dropped, 1, "OnDrop callback must fire on each drop")
+	require.Equal(t, "drop-me", dropped[0].Key)
+}
+
+// TestShardedChanSetOnDropNilClears asserts SetOnDrop(nil) cleanly clears a
+// previously-set callback.
+func TestShardedChanSetOnDropNilClears(t *testing.T) {
+	t.Parallel()
+
+	sc := NewShardedChan(1)
+	called := false
+	sc.SetOnDrop(func(Event) { called = true })
+	sc.SetOnDrop(nil)
+
+	for i := range 100 {
+		require.True(t, sc.SendWithTimeout(Event{Key: fmt.Sprintf("k-%d", i)}, time.Second))
+	}
+	_ = sc.SendWithTimeout(Event{Key: "drop"}, 10*time.Millisecond)
+	require.False(t, called, "cleared OnDrop must not fire")
+	require.Equal(t, int64(1), sc.Dropped(), "Dropped() still increments after SetOnDrop(nil)")
+}
+
 // TestLayeredPushReturnsEmbeddedError is the Push variant.
 func TestLayeredPushReturnsEmbeddedError(t *testing.T) {
 	t.Parallel()

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -47,6 +47,7 @@ type ServerInfo struct {
 	Workers           int           `json:"workers"`
 	Tick              time.Duration `json:"tick"`
 	WatchPanics       int64         `json:"watchPanics"`
+	DroppedEvents     int64         `json:"droppedEvents"`
 }
 
 // FilterInfo contains detailed information about a filter path


### PR DESCRIPTION
## Summary
Makes sharded-watcher send-timeout drops programmatically observable so operators can detect a stuck or slow consumer instead of having to grep logs. Mirrors the existing `OnWatchPanic` / `WatchPanics` pattern.

## Behaviour
Two storage-layer observation points:

- `ShardedChan.Dropped()` — atomic counter, total events dropped on timeout since startup.
- `ShardedChan.SetOnDrop(func(Event))` — optional callback that fires synchronously on the sender's goroutine for each dropped event, before the existing log line. Pass `nil` to clear.

The server wires both during `waitStart` to a `Server.DroppedEvents` atomic counter and an optional `Server.OnDroppedEvent` callback. `ui.ServerInfo.DroppedEvents` surfaces the counter to the explorer / `/stats` consumers alongside `WatchPanics`.

Default behaviour unchanged: drops still happen on timeout and still log; nothing in the existing happy path is altered.

## Scope notes (from self-review)
- A drop now writes two log lines (storage `log.Printf`, server `Console.Err`). The storage log pre-dates this change. Worth deciding whether the storage-layer log should be downgraded once operators rely on the counter + callback. Deferred to a separate follow-up.

## Test plan
- [x] `TestShardedChanDropIsObservable` — fills a single-shard channel, sends one more with a 10 ms timeout, asserts `Dropped()` increments and the `SetOnDrop` callback fires with the dropped event.
- [x] `TestShardedChanSetOnDropNilClears` — `SetOnDrop(nil)` cleanly clears a previously-installed callback; the counter still increments.
- [x] `TestOnDroppedEventReceivesOffendingEvent` — boots a `Server` with a blocking `OnStorageEvent`, synchronises on the worker actually dequeuing the first event, saturates the shard buffer, sends one more with a tight timeout, asserts the event surfaces through `OnDroppedEvent` and `Server.DroppedEvents`.
- [x] Full race suite green.

Closes #80

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)