### PR TITLE
fix(rest): cap publish/patch request bodies via MaxRequestBodyBytes

### DIFF
--- a/ooo.go
+++ b/ooo.go
@@ -29,6 +29,11 @@ import (
 
 const deadlineMsg = "ooo: server deadline reached"
 
+// DefaultMaxRequestBodyBytes is the default cap on REST request body size
+// (POST / PATCH). Override via Server.MaxRequestBodyBytes. Set the field to a
+// negative value to disable the cap.
+const DefaultMaxRequestBodyBytes = 10 * 1024 * 1024 // 10 MiB
+
 // audit requests function
 // will define approval or denial by the return value
 // r: the request to be audited
@@ -101,63 +106,64 @@ type audit func(r *http.Request) bool
 //
 // BeforeRead: callback function triggered before read operations
 type Server struct {
-	wg                 sync.WaitGroup
-	watchWg            sync.WaitGroup
-	listenWg           sync.WaitGroup
-	handlerWg          sync.WaitGroup
-	clockWg            sync.WaitGroup
-	server             *http.Server
-	Name               string
-	Router             *mux.Router
-	Stream             stream.Stream
-	filters            filters.Filters
-	limitFilters       map[string]*limitFilterReg // tracks limit filter registrations
-	endpoints          []ui.EndpointInfo          // registered custom endpoints
-	proxies            []ui.ProxyInfo             // registered proxy routes
-	routeOracle        *mux.Router                // mirrors Endpoint/Proxy paths so the data wildcard can defer to them
-	routeOracleMu      sync.Mutex                 // serializes oracle registrations and matches
-	proxyCleanups      []func()                   // cleanup functions for proxy subscriptions
-	proxyCleanupMu     sync.Mutex                 // protects proxyCleanups
-	NoBroadcastKeys    []string
-	Audit              audit
-	Workers            int
-	ForcePatch         bool
-	NoPatch            bool
-	OnSubscribe        stream.Subscribe
-	OnUnsubscribe      stream.Unsubscribe
-	OnStart            func()
-	OnClose            func()
-	preCloseCleanups   []func() // cleanup functions called before stream/storage close
-	preCloseCleanupsMu sync.Mutex
-	Deadline           time.Duration
-	AllowedOrigins     []string
-	AllowedMethods     []string
-	AllowedHeaders     []string
-	ExposedHeaders     []string
-	Storage            storage.Database
-	Address            string
-	closing            int64
-	active             int64
-	Silence            bool
-	Static             bool
-	Tick               time.Duration
-	Console            *coat.Console
-	Signal             chan os.Signal
-	Client             *http.Client
-	ReadTimeout        time.Duration
-	WriteTimeout       time.Duration
-	ReadHeaderTimeout  time.Duration
-	IdleTimeout        time.Duration
-	OnStorageEvent     storage.EventCallback
-	OnWatchPanic       func(ev storage.Event, r any) // optional: invoked on each recovered watch-goroutine panic with the offending event
-	OnDroppedEvent     func(ev storage.Event)        // optional: invoked when the sharded watcher channel drops an event after timing out
-	BeforeRead         func(key string)
-	GetPivotInfo       func() *ui.PivotInfo // Optional: returns pivot status for UI
-	NoCompress         bool                 // Disable gzip compression (useful for tests)
-	WatchPanics        int64                // Atomic counter of panics recovered in watch goroutines
-	DroppedEvents      int64                // Atomic counter of events dropped by the sharded watcher on send timeout
-	startErr           chan error           // channel for startup errors
-	clockStop          chan struct{}        // channel to signal clock goroutine to stop
+	wg                  sync.WaitGroup
+	watchWg             sync.WaitGroup
+	listenWg            sync.WaitGroup
+	handlerWg           sync.WaitGroup
+	clockWg             sync.WaitGroup
+	server              *http.Server
+	Name                string
+	Router              *mux.Router
+	Stream              stream.Stream
+	filters             filters.Filters
+	limitFilters        map[string]*limitFilterReg // tracks limit filter registrations
+	endpoints           []ui.EndpointInfo          // registered custom endpoints
+	proxies             []ui.ProxyInfo             // registered proxy routes
+	routeOracle         *mux.Router                // mirrors Endpoint/Proxy paths so the data wildcard can defer to them
+	routeOracleMu       sync.Mutex                 // serializes oracle registrations and matches
+	proxyCleanups       []func()                   // cleanup functions for proxy subscriptions
+	proxyCleanupMu      sync.Mutex                 // protects proxyCleanups
+	NoBroadcastKeys     []string
+	Audit               audit
+	Workers             int
+	ForcePatch          bool
+	NoPatch             bool
+	OnSubscribe         stream.Subscribe
+	OnUnsubscribe       stream.Unsubscribe
+	OnStart             func()
+	OnClose             func()
+	preCloseCleanups    []func() // cleanup functions called before stream/storage close
+	preCloseCleanupsMu  sync.Mutex
+	Deadline            time.Duration
+	AllowedOrigins      []string
+	AllowedMethods      []string
+	AllowedHeaders      []string
+	ExposedHeaders      []string
+	Storage             storage.Database
+	Address             string
+	closing             int64
+	active              int64
+	Silence             bool
+	Static              bool
+	Tick                time.Duration
+	Console             *coat.Console
+	Signal              chan os.Signal
+	Client              *http.Client
+	ReadTimeout         time.Duration
+	WriteTimeout        time.Duration
+	ReadHeaderTimeout   time.Duration
+	IdleTimeout         time.Duration
+	MaxRequestBodyBytes int64 // cap on REST request body size; defaults to DefaultMaxRequestBodyBytes (10 MiB). Set to a negative value to disable.
+	OnStorageEvent      storage.EventCallback
+	OnWatchPanic        func(ev storage.Event, r any) // optional: invoked on each recovered watch-goroutine panic with the offending event
+	OnDroppedEvent      func(ev storage.Event)        // optional: invoked when the sharded watcher channel drops an event after timing out
+	BeforeRead          func(key string)
+	GetPivotInfo        func() *ui.PivotInfo // Optional: returns pivot status for UI
+	NoCompress          bool                 // Disable gzip compression (useful for tests)
+	WatchPanics         int64                // Atomic counter of panics recovered in watch goroutines
+	DroppedEvents       int64                // Atomic counter of events dropped by the sharded watcher on send timeout
+	startErr            chan error           // channel for startup errors
+	clockStop           chan struct{}        // channel to signal clock goroutine to stop
 }
 
 // Validate checks the server configuration for common issues.
@@ -547,6 +553,9 @@ func (server *Server) defaultTimeouts() {
 	}
 	if server.IdleTimeout == 0 {
 		server.IdleTimeout = 10 * time.Second
+	}
+	if server.MaxRequestBodyBytes == 0 {
+		server.MaxRequestBodyBytes = DefaultMaxRequestBodyBytes
 	}
 }
 

--- a/rest.go
+++ b/rest.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 
@@ -36,8 +37,14 @@ func (server *Server) publish(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	event, err := messages.DecodeReader(r.Body)
+	body, probe := server.limitBody(w, r)
+	event, err := messages.DecodeReader(body)
 	if err != nil {
+		if isRequestBodyTooLargeErr(err) || (probe != nil && isRequestBodyTooLargeErr(probe.last)) {
+			w.WriteHeader(http.StatusRequestEntityTooLarge)
+			fmt.Fprintf(w, "%s", http.StatusText(http.StatusRequestEntityTooLarge))
+			return
+		}
 		w.WriteHeader(http.StatusBadRequest)
 		fmt.Fprintf(w, "%s", err)
 		return
@@ -89,8 +96,14 @@ func (server *Server) patch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	patchData, err := messages.DecodeReader(r.Body)
+	body, probe := server.limitBody(w, r)
+	patchData, err := messages.DecodeReader(body)
 	if err != nil {
+		if isRequestBodyTooLargeErr(err) || (probe != nil && isRequestBodyTooLargeErr(probe.last)) {
+			w.WriteHeader(http.StatusRequestEntityTooLarge)
+			fmt.Fprintf(w, "%s", http.StatusText(http.StatusRequestEntityTooLarge))
+			return
+		}
 		w.WriteHeader(http.StatusBadRequest)
 		fmt.Fprintf(w, "%s", err)
 		return
@@ -222,4 +235,60 @@ func (server *Server) unpublish(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(http.StatusNoContent)
 	w.Write([]byte(`"unpublish "+_key`))
+}
+
+// limitBody wraps r.Body with http.MaxBytesReader so a runaway POST/PATCH
+// cannot buffer arbitrary bytes into memory. A non-positive
+// MaxRequestBodyBytes disables the cap and returns r.Body unchanged so
+// operators can opt out (test harnesses, trusted internal callers).
+//
+// IMPORTANT: must be called before any write to w. http.MaxBytesReader
+// signals the response writer side-channel to suppress connection keep-alive
+// once the cap trips, and that side-channel is a no-op after the header has
+// been committed. Today both callers (publish, patch) short-circuit on auth
+// and key checks without writing to w first, so the invariant holds — refactor
+// that path with care.
+//
+// The returned readErrorProbe (non-nil only when the cap is active) records
+// the most recent error returned by Read. benitogf/go-json swallows
+// underlying reader errors as a plain io.EOF when it sees the truncated
+// payload, so callers must consult the probe to distinguish "client sent too
+// many bytes" (413) from "client sent invalid JSON" (400).
+func (server *Server) limitBody(w http.ResponseWriter, r *http.Request) (io.Reader, *readErrorProbe) {
+	if server.MaxRequestBodyBytes <= 0 {
+		return r.Body, nil
+	}
+	probe := &readErrorProbe{inner: http.MaxBytesReader(w, r.Body, server.MaxRequestBodyBytes)}
+	return probe, probe
+}
+
+// readErrorProbe wraps an io.Reader and remembers the most recent non-nil
+// error returned by Read, so callers can recover the underlying cause even
+// when an upstream decoder turns it into a less-specific error like EOF.
+type readErrorProbe struct {
+	inner io.Reader
+	last  error
+}
+
+func (p *readErrorProbe) Read(b []byte) (int, error) {
+	n, err := p.inner.Read(b)
+	if err != nil {
+		p.last = err
+	}
+	return n, err
+}
+
+// isRequestBodyTooLargeErr reports whether err originated in a
+// MaxBytesReader exhausting its quota. It matches both modern
+// *http.MaxBytesError and the legacy "http: request body too large"
+// sentinel that older stdlib paths still return.
+func isRequestBodyTooLargeErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	var maxErr *http.MaxBytesError
+	if errors.As(err, &maxErr) {
+		return true
+	}
+	return strings.Contains(err.Error(), "http: request body too large")
 }

--- a/rest_test.go
+++ b/rest_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/benitogf/go-json"
@@ -78,6 +79,82 @@ func TestRestPostKey(t *testing.T) {
 	server.Router.ServeHTTP(w, req)
 	resp := w.Result()
 	require.Equal(t, http.StatusMovedPermanently, resp.StatusCode)
+}
+
+// TestRestPostBodyTooLarge asserts a POST whose body exceeds
+// Server.MaxRequestBodyBytes is rejected with 413 Request Entity Too Large
+// instead of being buffered into memory. Pre-fix the handler called
+// messages.DecodeReader(r.Body) directly with no cap.
+func TestRestPostBodyTooLarge(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+	server := ooo.Server{}
+	server.Silence = true
+	server.MaxRequestBodyBytes = 64
+	server.Start("localhost:0")
+	defer server.Close(os.Interrupt)
+
+	body := []byte(`{"data":"` + strings.Repeat("x", 256) + `"}`)
+	req := httptest.NewRequest(http.MethodPost, "/k", bytes.NewBuffer(body))
+	w := httptest.NewRecorder()
+	server.Router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusRequestEntityTooLarge, w.Result().StatusCode)
+}
+
+// TestRestPatchBodyTooLarge is the PATCH variant.
+func TestRestPatchBodyTooLarge(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+	server := ooo.Server{}
+	server.Silence = true
+	server.MaxRequestBodyBytes = 64
+	server.Start("localhost:0")
+	defer server.Close(os.Interrupt)
+
+	body := []byte(`{"data":"` + strings.Repeat("x", 256) + `"}`)
+	req := httptest.NewRequest(http.MethodPatch, "/k", bytes.NewBuffer(body))
+	w := httptest.NewRecorder()
+	server.Router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusRequestEntityTooLarge, w.Result().StatusCode)
+}
+
+// TestRestPostBodyUnderLimit asserts a POST under the cap still succeeds.
+func TestRestPostBodyUnderLimit(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+	server := ooo.Server{}
+	server.Silence = true
+	server.MaxRequestBodyBytes = 4096
+	server.Start("localhost:0")
+	defer server.Close(os.Interrupt)
+
+	body := []byte(`{"data":"small"}`)
+	req := httptest.NewRequest(http.MethodPost, "/k", bytes.NewBuffer(body))
+	w := httptest.NewRecorder()
+	server.Router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Result().StatusCode)
+}
+
+// TestRestPostBodyDisabledLimit asserts a negative MaxRequestBodyBytes opts
+// out of the cap entirely (escape hatch for trusted internal callers).
+func TestRestPostBodyDisabledLimit(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+	server := ooo.Server{}
+	server.Silence = true
+	server.MaxRequestBodyBytes = -1
+	server.Start("localhost:0")
+	defer server.Close(os.Interrupt)
+
+	body := []byte(`{"data":"` + strings.Repeat("x", 1024) + `"}`)
+	req := httptest.NewRequest(http.MethodPost, "/k", bytes.NewBuffer(body))
+	w := httptest.NewRecorder()
+	server.Router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Result().StatusCode)
 }
 
 func TestRestDel(t *testing.T) {


### PR DESCRIPTION
## Summary
Caps REST request bodies on `publish` (POST) and `patch` (PATCH) so a single oversized request can no longer buffer arbitrary bytes into server memory. The default cap is 10 MiB; deployments that need more can raise it or opt out entirely.

## Behaviour
- `Server.MaxRequestBodyBytes int64` is a new public field. Zero (the default) selects `DefaultMaxRequestBodyBytes` = 10 MiB. A positive value sets the cap directly. A negative value disables the cap.
- POST and PATCH wrap `r.Body` in `http.MaxBytesReader` before decoding. A request that exceeds the cap is rejected with **413 Request Entity Too Large**.
- `benitogf/go-json` (ooo's JSON fork) swallows the underlying `*http.MaxBytesError` as `io.EOF`. A small `readErrorProbe` records the last Read error so the handler can still return 413 instead of a misleading 400.

## Behaviour change for existing deployments
Callers that previously POSTed/PATCHed bodies larger than 10 MiB without configuring `MaxRequestBodyBytes` will start receiving 413. Set `Server.MaxRequestBodyBytes` to a larger value (or `-1` to disable) to restore the prior behaviour.

## Scope notes (from self-review)
- The MaxBytesReader / ResponseWriter side-channel that suppresses keep-alive only fires if `limitBody` runs before any write to `w`. Both handlers short-circuit on auth and key checks without writing first, so the invariant holds today. The constraint is now documented in `limitBody`'s doc-comment so a future refactor won't silently break it.
- Custom `Endpoint` and `Proxy` handlers registered via `server.Endpoint(...)` / `proxy.Route(...)` still read `r.Body` directly and do not inherit the cap. That's a separate concern (their authors own the body contract); could be a follow-up to expose `limitBody` as a public middleware.

## Test plan
- [x] `TestRestPostBodyTooLarge` / `TestRestPatchBodyTooLarge` — POST/PATCH with a body that exceeds a configured 64-byte cap returns 413.
- [x] `TestRestPostBodyUnderLimit` — a modest POST under the cap still returns 200.
- [x] `TestRestPostBodyDisabledLimit` — `MaxRequestBodyBytes = -1` lets a 1 KiB body through.
- [x] Full race suite green.

Closes #82

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)