### PR TITLE
fix(proxy): cap and stream POST/PATCH bodies to upstream

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -657,6 +657,15 @@ func handleWebSocketProxy(w http.ResponseWriter, r *http.Request, pm *proxyManag
 // turns a 307/308 redirect into an unambiguous failure instead of the
 // stdlib's "http: cannot redirect with body" message.
 func proxyWrite(server *ooo.Server, w http.ResponseWriter, r *http.Request, method, targetURL string, header http.Header, httpClient *http.Client) {
+	// Honest clients that declare an oversize Content-Length can be
+	// rejected before we open the upstream TCP connection. A dishonest
+	// client that lies about its length still trips the cap mid-stream
+	// via the LimitBody wrap below, so this guard is an optimization,
+	// not the correctness boundary.
+	if server.MaxRequestBodyBytes > 0 && r.ContentLength > server.MaxRequestBodyBytes {
+		http.Error(w, http.StatusText(http.StatusRequestEntityTooLarge), http.StatusRequestEntityTooLarge)
+		return
+	}
 	body, probe := server.LimitBody(w, r)
 
 	req, err := http.NewRequestWithContext(r.Context(), method, targetURL, body)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1,7 +1,6 @@
 package proxy
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -478,7 +477,7 @@ func Route(server *ooo.Server, localPath string, cfg Config) error {
 		}
 
 		// Handle HTTP requests
-		handleHTTPProxy(w, r, address, remotePath, cfg.Subscribe)
+		handleHTTPProxy(server, w, r, address, remotePath, cfg.Subscribe)
 	}
 
 	// Convert glob pattern to mux pattern
@@ -549,7 +548,7 @@ func RouteList(server *ooo.Server, localPath string, cfg Config) error {
 			return
 		}
 
-		handleHTTPProxy(w, r, address, remotePath, cfg.Subscribe)
+		handleHTTPProxy(server, w, r, address, remotePath, cfg.Subscribe)
 	}
 
 	// Handler for specific items
@@ -567,7 +566,7 @@ func RouteList(server *ooo.Server, localPath string, cfg Config) error {
 			return
 		}
 
-		handleHTTPProxy(w, r, address, remotePath, cfg.Subscribe)
+		handleHTTPProxy(server, w, r, address, remotePath, cfg.Subscribe)
 	}
 
 	// Convert glob pattern to mux pattern
@@ -644,7 +643,67 @@ func handleWebSocketProxy(w http.ResponseWriter, r *http.Request, pm *proxyManag
 	}
 }
 
-func handleHTTPProxy(w http.ResponseWriter, r *http.Request, address, remotePath string, subCfg *client.SubscribeConfig) {
+// proxyWrite streams a POST/PATCH body to upstream under the server's
+// MaxRequestBodyBytes cap. The body is passed directly to the upstream
+// request instead of buffered into memory, so a runaway client cannot
+// force the proxy to allocate arbitrary bytes. If the cap trips during
+// upstream transport, the client gets 413 instead of a generic 502.
+//
+// Wire framing is preserved from the client: req.ContentLength is forwarded
+// so upstreams that reject chunked POST/PATCH (older non-Go servers, some
+// content-inspection middleware) continue to receive Content-Length when
+// the client sent one. MaxBytesReader is stateful and cannot be replayed,
+// so req.GetBody is set to a sentinel error rather than left nil — that
+// turns a 307/308 redirect into an unambiguous failure instead of the
+// stdlib's "http: cannot redirect with body" message.
+func proxyWrite(server *ooo.Server, w http.ResponseWriter, r *http.Request, method, targetURL string, header http.Header, httpClient *http.Client) {
+	body, probe := server.LimitBody(w, r)
+
+	req, err := http.NewRequestWithContext(r.Context(), method, targetURL, body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	req.ContentLength = r.ContentLength
+	req.GetBody = func() (io.ReadCloser, error) {
+		return nil, errors.New("proxy: request body not replayable after streaming")
+	}
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range header {
+		req.Header[k] = v
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		// MaxBytesReader trips during upstream transport. Distinguish
+		// "client sent too many bytes" (413) from "client hung up mid
+		// body" (400) and from generic transport failures (502).
+		// The probe holds the underlying Read error when transport
+		// surfaces a less-specific one.
+		if ooo.IsRequestBodyTooLargeErr(err) || (probe != nil && ooo.IsRequestBodyTooLargeErr(probe.Last())) {
+			http.Error(w, http.StatusText(http.StatusRequestEntityTooLarge), http.StatusRequestEntityTooLarge)
+			return
+		}
+		// probe.Last() captures io.EOF on a clean read of the full body,
+		// so only treat non-EOF read errors as a client-side fault.
+		// ErrUnexpectedEOF and friends fall into this branch.
+		if probe != nil && probe.Last() != nil && !errors.Is(probe.Last(), io.EOF) {
+			http.Error(w, probe.Last().Error(), http.StatusBadRequest)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	for k, v := range resp.Header {
+		w.Header()[k] = v
+	}
+	w.WriteHeader(resp.StatusCode)
+	io.Copy(w, resp.Body)
+}
+
+func handleHTTPProxy(server *ooo.Server, w http.ResponseWriter, r *http.Request, address, remotePath string, subCfg *client.SubscribeConfig) {
 	scheme := "http"
 	if subCfg != nil && subCfg.Server.Protocol == "wss" {
 		scheme = "https"
@@ -685,34 +744,7 @@ func handleHTTPProxy(w http.ResponseWriter, r *http.Request, address, remotePath
 		io.Copy(w, resp.Body)
 
 	case http.MethodPost:
-		body, err := io.ReadAll(r.Body)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-
-		req, err := http.NewRequestWithContext(r.Context(), http.MethodPost, targetURL, bytes.NewReader(body))
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		req.Header.Set("Content-Type", "application/json")
-		for k, v := range header {
-			req.Header[k] = v
-		}
-
-		resp, err := httpClient.Do(req)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadGateway)
-			return
-		}
-		defer resp.Body.Close()
-
-		for k, v := range resp.Header {
-			w.Header()[k] = v
-		}
-		w.WriteHeader(resp.StatusCode)
-		io.Copy(w, resp.Body)
+		proxyWrite(server, w, r, http.MethodPost, targetURL, header, httpClient)
 
 	case http.MethodDelete:
 		req, err := http.NewRequestWithContext(r.Context(), http.MethodDelete, targetURL, nil)
@@ -738,34 +770,7 @@ func handleHTTPProxy(w http.ResponseWriter, r *http.Request, address, remotePath
 		io.Copy(w, resp.Body)
 
 	case http.MethodPatch:
-		body, err := io.ReadAll(r.Body)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-
-		req, err := http.NewRequestWithContext(r.Context(), http.MethodPatch, targetURL, bytes.NewReader(body))
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		req.Header.Set("Content-Type", "application/json")
-		for k, v := range header {
-			req.Header[k] = v
-		}
-
-		resp, err := httpClient.Do(req)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadGateway)
-			return
-		}
-		defer resp.Body.Close()
-
-		for k, v := range resp.Header {
-			w.Header()[k] = v
-		}
-		w.WriteHeader(resp.StatusCode)
-		io.Copy(w, resp.Body)
+		proxyWrite(server, w, r, http.MethodPatch, targetURL, header, httpClient)
 
 	default:
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -811,7 +816,7 @@ func RouteWithVars(server *ooo.Server, localPath string, cfg Config) error {
 			return
 		}
 
-		handleHTTPProxy(w, r, address, remotePath, cfg.Subscribe)
+		handleHTTPProxy(server, w, r, address, remotePath, cfg.Subscribe)
 	}
 
 	server.Router.HandleFunc("/"+localPath, handler)

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -2,6 +2,7 @@ package proxy_test
 
 import (
 	"bytes"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -1083,6 +1084,104 @@ func TestProxyForwardsContentLength(t *testing.T) {
 	defer mu.Unlock()
 	require.Equal(t, int64(len(body)), seenContentLength, "upstream should see Content-Length matching client body")
 	require.Empty(t, seenTransferEnc, "upstream should not see Transfer-Encoding: chunked")
+}
+
+// TestProxyForwardsChunkedFromClient asserts the streamed-body proxy
+// preserves the client's chunked transfer-encoding when the client did
+// not declare a Content-Length. The complement to
+// TestProxyForwardsContentLength: that test guards against the streamed
+// path silently switching to chunked for Content-Length clients; this
+// test guards against a future change that would clamp r.ContentLength
+// (or otherwise force Content-Length) and silently break chunked
+// clients.
+func TestProxyForwardsChunkedFromClient(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+
+	var (
+		mu                sync.Mutex
+		seenContentLength int64
+		seenTransferEnc   []string
+	)
+	upstream := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		seenContentLength = r.ContentLength
+		seenTransferEnc = append([]string(nil), r.TransferEncoding...)
+		mu.Unlock()
+	}))
+	defer upstream.Close()
+	upstreamHost := strings.TrimPrefix(upstream.URL, "http://")
+
+	proxyServer := &ooo.Server{}
+	proxyServer.Silence = true
+	proxyServer.MaxRequestBodyBytes = 4096
+
+	err := proxy.Route(proxyServer, "settings/{deviceID}", proxy.Config{
+		Resolve: func(_ string) (string, string, error) {
+			return upstreamHost, "", nil
+		},
+	})
+	require.NoError(t, err)
+	proxyServer.Start("localhost:0")
+	defer proxyServer.Close(os.Interrupt)
+
+	body := []byte(`{"name":"small","value":1}`)
+	req, err := http.NewRequest(http.MethodPost, "http://"+proxyServer.Address+"/settings/device1", bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	// Force chunked by hiding the length from the transport: stdlib
+	// only auto-derives Content-Length for *bytes.Reader / *bytes.Buffer
+	// / *strings.Reader bodies, so wrapping in io.NopCloser produces a
+	// chunked request.
+	req.Body = io.NopCloser(bytes.NewReader(body))
+	req.ContentLength = -1
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, int64(-1), seenContentLength, "upstream should see no Content-Length when client uses chunked")
+	require.Equal(t, []string{"chunked"}, seenTransferEnc, "upstream should see chunked Transfer-Encoding")
+}
+
+// TestProxyPostBodyTooLargeDeclared asserts an honest client that
+// declares an oversize Content-Length is rejected with 413 before the
+// proxy opens an upstream TCP connection. The cap should be a
+// pre-flight check, not just a mid-stream trip.
+func TestProxyPostBodyTooLargeDeclared(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+
+	var upstreamHit bool
+	upstream := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		upstreamHit = true
+	}))
+	defer upstream.Close()
+	upstreamHost := strings.TrimPrefix(upstream.URL, "http://")
+
+	proxyServer := &ooo.Server{}
+	proxyServer.Silence = true
+	proxyServer.MaxRequestBodyBytes = 64
+
+	err := proxy.Route(proxyServer, "settings/{deviceID}", proxy.Config{
+		Resolve: func(_ string) (string, string, error) {
+			return upstreamHost, "", nil
+		},
+	})
+	require.NoError(t, err)
+	proxyServer.Start("localhost:0")
+	defer proxyServer.Close(os.Interrupt)
+
+	body := []byte(`{"data":"` + strings.Repeat("x", 256) + `"}`)
+	resp, err := http.Post("http://"+proxyServer.Address+"/settings/device1", "application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusRequestEntityTooLarge, resp.StatusCode)
+	require.False(t, upstreamHit, "upstream should not be contacted for a declared-oversize request")
 }
 
 // TestProxyPostBodyDisabledLimit asserts MaxRequestBodyBytes <= 0 opts the

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -3,6 +3,7 @@ package proxy_test
 import (
 	"bytes"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"runtime"
@@ -929,6 +930,190 @@ func TestProxyWebSocketWithBearerTokenAuthRequired(t *testing.T) {
 	require.NoError(t, err, "should receive message from authenticated remote")
 	require.NotEmpty(t, message)
 	require.Contains(t, string(message), "protected", "should receive protected data after successful auth")
+}
+
+// TestProxyPostBodyTooLarge asserts a proxied POST whose body exceeds
+// the proxy server's MaxRequestBodyBytes is rejected with 413 instead of
+// being buffered into memory. Pre-fix handleHTTPProxy did io.ReadAll on
+// r.Body with no cap, so a runaway client could force the proxy to
+// allocate arbitrary bytes per request.
+func TestProxyPostBodyTooLarge(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+	remote := &ooo.Server{}
+	remote.Silence = true
+	remote.Start("localhost:0")
+	defer remote.Close(os.Interrupt)
+
+	proxyServer := &ooo.Server{}
+	proxyServer.Silence = true
+	proxyServer.MaxRequestBodyBytes = 64
+
+	err := proxy.Route(proxyServer, "settings/{deviceID}", proxy.Config{
+		Resolve: func(_ string) (string, string, error) {
+			return remote.Address, "settings", nil
+		},
+	})
+	require.NoError(t, err)
+	proxyServer.Start("localhost:0")
+	defer proxyServer.Close(os.Interrupt)
+
+	body := []byte(`{"data":"` + strings.Repeat("x", 256) + `"}`)
+	resp, err := http.Post("http://"+proxyServer.Address+"/settings/device1", "application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusRequestEntityTooLarge, resp.StatusCode)
+}
+
+// TestProxyPatchBodyTooLarge is the PATCH variant of body-cap enforcement.
+func TestProxyPatchBodyTooLarge(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+	remote := &ooo.Server{}
+	remote.Silence = true
+	remote.Start("localhost:0")
+	defer remote.Close(os.Interrupt)
+
+	// Seed remote so the upstream path is reachable; the 413 should fire
+	// before the upstream ever sees the body.
+	_, err := remote.Storage.Set("settings", []byte(`{"name":"seed","value":1}`))
+	require.NoError(t, err)
+
+	proxyServer := &ooo.Server{}
+	proxyServer.Silence = true
+	proxyServer.MaxRequestBodyBytes = 64
+
+	err = proxy.Route(proxyServer, "settings/{deviceID}", proxy.Config{
+		Resolve: func(_ string) (string, string, error) {
+			return remote.Address, "settings", nil
+		},
+	})
+	require.NoError(t, err)
+	proxyServer.Start("localhost:0")
+	defer proxyServer.Close(os.Interrupt)
+
+	body := []byte(`{"data":"` + strings.Repeat("x", 256) + `"}`)
+	req, err := http.NewRequest(http.MethodPatch, "http://"+proxyServer.Address+"/settings/device1", bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusRequestEntityTooLarge, resp.StatusCode)
+}
+
+// TestProxyPostBodyUnderLimit asserts a POST whose body fits under the
+// proxy cap is forwarded successfully to the upstream.
+func TestProxyPostBodyUnderLimit(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+	remote := &ooo.Server{}
+	remote.Silence = true
+	remote.Start("localhost:0")
+	defer remote.Close(os.Interrupt)
+
+	proxyServer := &ooo.Server{}
+	proxyServer.Silence = true
+	proxyServer.MaxRequestBodyBytes = 4096
+
+	err := proxy.Route(proxyServer, "settings/{deviceID}", proxy.Config{
+		Resolve: func(_ string) (string, string, error) {
+			return remote.Address, "settings", nil
+		},
+	})
+	require.NoError(t, err)
+	proxyServer.Start("localhost:0")
+	defer proxyServer.Close(os.Interrupt)
+
+	body := []byte(`{"name":"small","value":1}`)
+	resp, err := http.Post("http://"+proxyServer.Address+"/settings/device1", "application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+// TestProxyForwardsContentLength asserts the streamed-body proxy path
+// preserves the client's Content-Length on the upstream request instead
+// of switching to chunked Transfer-Encoding. Upstreams that reject
+// chunked POST/PATCH (older non-Go servers, certain content-inspection
+// middleware) rely on Content-Length being set; pre-fix the buffered
+// path produced this for free via bytes.NewReader.
+func TestProxyForwardsContentLength(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+
+	var (
+		mu                sync.Mutex
+		seenContentLength int64
+		seenTransferEnc   []string
+	)
+	upstream := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		seenContentLength = r.ContentLength
+		seenTransferEnc = append([]string(nil), r.TransferEncoding...)
+		mu.Unlock()
+	}))
+	defer upstream.Close()
+	upstreamHost := strings.TrimPrefix(upstream.URL, "http://")
+
+	proxyServer := &ooo.Server{}
+	proxyServer.Silence = true
+	proxyServer.MaxRequestBodyBytes = 4096
+
+	err := proxy.Route(proxyServer, "settings/{deviceID}", proxy.Config{
+		Resolve: func(_ string) (string, string, error) {
+			return upstreamHost, "", nil
+		},
+	})
+	require.NoError(t, err)
+	proxyServer.Start("localhost:0")
+	defer proxyServer.Close(os.Interrupt)
+
+	body := []byte(`{"name":"small","value":1}`)
+	resp, err := http.Post("http://"+proxyServer.Address+"/settings/device1", "application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, int64(len(body)), seenContentLength, "upstream should see Content-Length matching client body")
+	require.Empty(t, seenTransferEnc, "upstream should not see Transfer-Encoding: chunked")
+}
+
+// TestProxyPostBodyDisabledLimit asserts MaxRequestBodyBytes <= 0 opts the
+// proxy out of body capping entirely (escape hatch for trusted callers).
+func TestProxyPostBodyDisabledLimit(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+	remote := &ooo.Server{}
+	remote.Silence = true
+	remote.Start("localhost:0")
+	defer remote.Close(os.Interrupt)
+
+	proxyServer := &ooo.Server{}
+	proxyServer.Silence = true
+	proxyServer.MaxRequestBodyBytes = -1
+
+	err := proxy.Route(proxyServer, "settings/{deviceID}", proxy.Config{
+		Resolve: func(_ string) (string, string, error) {
+			return remote.Address, "settings", nil
+		},
+	})
+	require.NoError(t, err)
+	proxyServer.Start("localhost:0")
+	defer proxyServer.Close(os.Interrupt)
+
+	body := []byte(`{"data":"` + strings.Repeat("x", 1024) + `"}`)
+	resp, err := http.Post("http://"+proxyServer.Address+"/settings/device1", "application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
 func TestProxyServerCloseTearsDownSubscriptions(t *testing.T) {

--- a/rest.go
+++ b/rest.go
@@ -37,10 +37,10 @@ func (server *Server) publish(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, probe := server.limitBody(w, r)
+	body, probe := server.LimitBody(w, r)
 	event, err := messages.DecodeReader(body)
 	if err != nil {
-		if isRequestBodyTooLargeErr(err) || (probe != nil && isRequestBodyTooLargeErr(probe.last)) {
+		if IsRequestBodyTooLargeErr(err) || (probe != nil && IsRequestBodyTooLargeErr(probe.last)) {
 			w.WriteHeader(http.StatusRequestEntityTooLarge)
 			fmt.Fprintf(w, "%s", http.StatusText(http.StatusRequestEntityTooLarge))
 			return
@@ -96,10 +96,10 @@ func (server *Server) patch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, probe := server.limitBody(w, r)
+	body, probe := server.LimitBody(w, r)
 	patchData, err := messages.DecodeReader(body)
 	if err != nil {
-		if isRequestBodyTooLargeErr(err) || (probe != nil && isRequestBodyTooLargeErr(probe.last)) {
+		if IsRequestBodyTooLargeErr(err) || (probe != nil && IsRequestBodyTooLargeErr(probe.last)) {
 			w.WriteHeader(http.StatusRequestEntityTooLarge)
 			fmt.Fprintf(w, "%s", http.StatusText(http.StatusRequestEntityTooLarge))
 			return
@@ -237,7 +237,7 @@ func (server *Server) unpublish(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(`"unpublish "+_key`))
 }
 
-// limitBody wraps r.Body with http.MaxBytesReader so a runaway POST/PATCH
+// LimitBody wraps r.Body with http.MaxBytesReader so a runaway POST/PATCH
 // cannot buffer arbitrary bytes into memory. A non-positive
 // MaxRequestBodyBytes disables the cap and returns r.Body unchanged so
 // operators can opt out (test harnesses, trusted internal callers).
@@ -245,32 +245,39 @@ func (server *Server) unpublish(w http.ResponseWriter, r *http.Request) {
 // IMPORTANT: must be called before any write to w. http.MaxBytesReader
 // signals the response writer side-channel to suppress connection keep-alive
 // once the cap trips, and that side-channel is a no-op after the header has
-// been committed. Today both callers (publish, patch) short-circuit on auth
-// and key checks without writing to w first, so the invariant holds — refactor
-// that path with care.
+// been committed. Today both REST callers (publish, patch) short-circuit on
+// auth and key checks without writing to w first, so the invariant holds —
+// refactor that path with care. Same constraint applies to any other caller
+// (proxy handlers, custom Endpoints).
 //
-// The returned readErrorProbe (non-nil only when the cap is active) records
-// the most recent error returned by Read. benitogf/go-json swallows
-// underlying reader errors as a plain io.EOF when it sees the truncated
-// payload, so callers must consult the probe to distinguish "client sent too
-// many bytes" (413) from "client sent invalid JSON" (400).
-func (server *Server) limitBody(w http.ResponseWriter, r *http.Request) (io.Reader, *readErrorProbe) {
+// The returned ReadErrorProbe (non-nil only when the cap is active) records
+// the most recent error returned by Read. benitogf/go-json is known to
+// swallow underlying reader errors as a plain io.EOF when it sees the
+// truncated payload, so REST callers must consult the probe to distinguish
+// "client sent too many bytes" (413) from "client sent invalid JSON" (400).
+// Other consumers (notably net/http transports surfacing the body to an
+// upstream) may surface a less-specific cause; the probe is the defensive
+// fallback there as well.
+func (server *Server) LimitBody(w http.ResponseWriter, r *http.Request) (io.Reader, *ReadErrorProbe) {
 	if server.MaxRequestBodyBytes <= 0 {
 		return r.Body, nil
 	}
-	probe := &readErrorProbe{inner: http.MaxBytesReader(w, r.Body, server.MaxRequestBodyBytes)}
+	probe := &ReadErrorProbe{inner: http.MaxBytesReader(w, r.Body, server.MaxRequestBodyBytes)}
 	return probe, probe
 }
 
-// readErrorProbe wraps an io.Reader and remembers the most recent non-nil
+// ReadErrorProbe wraps an io.Reader and remembers the most recent non-nil
 // error returned by Read, so callers can recover the underlying cause even
-// when an upstream decoder turns it into a less-specific error like EOF.
-type readErrorProbe struct {
+// when an upstream decoder or transport turns it into a less-specific error
+// like EOF.
+type ReadErrorProbe struct {
 	inner io.Reader
 	last  error
 }
 
-func (p *readErrorProbe) Read(b []byte) (int, error) {
+// Read forwards to the wrapped reader and records any non-nil error so
+// callers can later disambiguate the cause via Last().
+func (p *ReadErrorProbe) Read(b []byte) (int, error) {
 	n, err := p.inner.Read(b)
 	if err != nil {
 		p.last = err
@@ -278,11 +285,17 @@ func (p *readErrorProbe) Read(b []byte) (int, error) {
 	return n, err
 }
 
-// isRequestBodyTooLargeErr reports whether err originated in a
+// Last returns the most recent error observed during Read. Returns nil if
+// Read never failed.
+func (p *ReadErrorProbe) Last() error {
+	return p.last
+}
+
+// IsRequestBodyTooLargeErr reports whether err originated in a
 // MaxBytesReader exhausting its quota. It matches both modern
 // *http.MaxBytesError and the legacy "http: request body too large"
 // sentinel that older stdlib paths still return.
-func isRequestBodyTooLargeErr(err error) bool {
+func IsRequestBodyTooLargeErr(err error) bool {
 	if err == nil {
 		return false
 	}


### PR DESCRIPTION
Closes #84

## Summary
- Stream proxied POST/PATCH bodies to upstream instead of buffering with `io.ReadAll`, applying the proxy server's existing request-body cap.
- Distinguish failure modes: oversize body returns 413, client hangup returns 400, upstream transport failure returns 502.
- Preserve the client's `Content-Length` on the upstream request so non-Go upstreams that reject chunked transfer-encoding continue to work.

## Test plan
- [x] `go test ./proxy/ -race` — new tests cover POST/PATCH overflow (413), under-limit success, escape-hatch (cap disabled), and `Content-Length` preservation against a `httptest` upstream.
- [x] `go test ./...` with `-race` — full suite green.
- [x] `gofmt` clean on changed files; `deadcode` clean for the new exported surface.
- [x] Pre-flight self-review by a fresh sub-agent surfaced 4 non-blockers — wire-framing regression, redirect replay, 400/502 disambiguation, doc-comment overclaim — all addressed in this same PR.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)