### PR TITLE
fix(proxy): enforce per-route Capabilities at the handler layer

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -82,6 +82,39 @@ func (c *Config) canDelete() bool {
 	return c.Capabilities.Delete
 }
 
+// enforceCapability writes 403 + returns false when the request method
+// is denied by the route's Capabilities. WebSocket upgrade requests are
+// gated by Read (a proxied WS subscription is a read on this codebase).
+// Unknown methods are passed through and rejected as 405 by the
+// downstream handler. The check fires before Resolve and before any
+// upstream contact, so denied requests never reach the target.
+func (c *Config) enforceCapability(w http.ResponseWriter, r *http.Request) bool {
+	if c.Capabilities == nil {
+		return true
+	}
+	if websocket.IsWebSocketUpgrade(r) {
+		if c.canRead() {
+			return true
+		}
+		http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+		return false
+	}
+	allowed := true
+	switch r.Method {
+	case http.MethodGet:
+		allowed = c.canRead()
+	case http.MethodPost, http.MethodPatch:
+		allowed = c.canWrite()
+	case http.MethodDelete:
+		allowed = c.canDelete()
+	}
+	if !allowed {
+		http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+		return false
+	}
+	return true
+}
+
 // proxyManager manages shared remote subscriptions.
 type proxyManager struct {
 	mu      sync.RWMutex
@@ -461,6 +494,9 @@ func Route(server *ooo.Server, localPath string, cfg Config) error {
 	}
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
+		if !cfg.enforceCapability(w, r) {
+			return
+		}
 		// Get the actual path from the request
 		actualPath := strings.TrimPrefix(r.URL.Path, "/")
 
@@ -535,6 +571,9 @@ func RouteList(server *ooo.Server, localPath string, cfg Config) error {
 
 	// Handler for the base path (list)
 	listHandler := func(w http.ResponseWriter, r *http.Request) {
+		if !cfg.enforceCapability(w, r) {
+			return
+		}
 		actualPath := strings.TrimPrefix(r.URL.Path, "/")
 
 		address, remotePath, err := cfg.Resolve(actualPath)
@@ -553,6 +592,9 @@ func RouteList(server *ooo.Server, localPath string, cfg Config) error {
 
 	// Handler for specific items
 	itemHandler := func(w http.ResponseWriter, r *http.Request) {
+		if !cfg.enforceCapability(w, r) {
+			return
+		}
 		actualPath := strings.TrimPrefix(r.URL.Path, "/")
 
 		address, remotePath, err := cfg.Resolve(actualPath)
@@ -808,6 +850,9 @@ func RouteWithVars(server *ooo.Server, localPath string, cfg Config) error {
 	}
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
+		if !cfg.enforceCapability(w, r) {
+			return
+		}
 		vars := mux.Vars(r)
 		actualPath := strings.TrimPrefix(r.URL.Path, "/")
 

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -3,11 +3,13 @@ package proxy_test
 import (
 	"bytes"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -1213,6 +1215,279 @@ func TestProxyPostBodyDisabledLimit(t *testing.T) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+// TestProxyCapabilitiesWriteDeniedRejectsPost asserts a route declared
+// with Capabilities{Write: false} refuses proxied POST requests with
+// 403 Forbidden instead of forwarding them. Pre-fix Capabilities was
+// reflected in the UI surface only and the handlers did not consult
+// it, so the documented restriction was a no-op.
+func TestProxyCapabilitiesWriteDeniedRejectsPost(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+
+	var upstreamHit bool
+	upstream := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		upstreamHit = true
+	}))
+	defer upstream.Close()
+	upstreamHost := strings.TrimPrefix(upstream.URL, "http://")
+
+	proxyServer := &ooo.Server{}
+	proxyServer.Silence = true
+
+	err := proxy.Route(proxyServer, "settings/{deviceID}", proxy.Config{
+		Capabilities: &proxy.Capabilities{Read: true, Write: false, Delete: true},
+		Resolve: func(_ string) (string, string, error) {
+			return upstreamHost, "", nil
+		},
+	})
+	require.NoError(t, err)
+	proxyServer.Start("localhost:0")
+	defer proxyServer.Close(os.Interrupt)
+
+	resp, err := http.Post("http://"+proxyServer.Address+"/settings/device1", "application/json", bytes.NewReader([]byte(`{"x":1}`)))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusForbidden, resp.StatusCode)
+	require.False(t, upstreamHit, "upstream must not see denied requests")
+}
+
+// TestProxyCapabilitiesWriteDeniedRejectsPatch is the PATCH variant.
+func TestProxyCapabilitiesWriteDeniedRejectsPatch(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+
+	var upstreamHit bool
+	upstream := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		upstreamHit = true
+	}))
+	defer upstream.Close()
+	upstreamHost := strings.TrimPrefix(upstream.URL, "http://")
+
+	proxyServer := &ooo.Server{}
+	proxyServer.Silence = true
+
+	err := proxy.Route(proxyServer, "settings/{deviceID}", proxy.Config{
+		Capabilities: &proxy.Capabilities{Read: true, Write: false, Delete: true},
+		Resolve: func(_ string) (string, string, error) {
+			return upstreamHost, "", nil
+		},
+	})
+	require.NoError(t, err)
+	proxyServer.Start("localhost:0")
+	defer proxyServer.Close(os.Interrupt)
+
+	req, err := http.NewRequest(http.MethodPatch, "http://"+proxyServer.Address+"/settings/device1", bytes.NewReader([]byte(`{"x":1}`)))
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusForbidden, resp.StatusCode)
+	require.False(t, upstreamHit)
+}
+
+// TestProxyCapabilitiesReadDeniedRejectsGet asserts Read: false blocks
+// GET requests through the proxy.
+func TestProxyCapabilitiesReadDeniedRejectsGet(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+
+	var upstreamHit bool
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamHit = true
+		w.Write([]byte(`{}`))
+	}))
+	defer upstream.Close()
+	upstreamHost := strings.TrimPrefix(upstream.URL, "http://")
+
+	proxyServer := &ooo.Server{}
+	proxyServer.Silence = true
+
+	err := proxy.Route(proxyServer, "settings/{deviceID}", proxy.Config{
+		Capabilities: &proxy.Capabilities{Read: false, Write: true, Delete: true},
+		Resolve: func(_ string) (string, string, error) {
+			return upstreamHost, "", nil
+		},
+	})
+	require.NoError(t, err)
+	proxyServer.Start("localhost:0")
+	defer proxyServer.Close(os.Interrupt)
+
+	resp, err := http.Get("http://" + proxyServer.Address + "/settings/device1")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusForbidden, resp.StatusCode)
+	require.False(t, upstreamHit)
+}
+
+// TestProxyCapabilitiesDeleteDeniedRejectsDelete asserts Delete: false
+// blocks DELETE requests through the proxy.
+func TestProxyCapabilitiesDeleteDeniedRejectsDelete(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+
+	var upstreamHit bool
+	upstream := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		upstreamHit = true
+	}))
+	defer upstream.Close()
+	upstreamHost := strings.TrimPrefix(upstream.URL, "http://")
+
+	proxyServer := &ooo.Server{}
+	proxyServer.Silence = true
+
+	err := proxy.Route(proxyServer, "settings/{deviceID}", proxy.Config{
+		Capabilities: &proxy.Capabilities{Read: true, Write: true, Delete: false},
+		Resolve: func(_ string) (string, string, error) {
+			return upstreamHost, "", nil
+		},
+	})
+	require.NoError(t, err)
+	proxyServer.Start("localhost:0")
+	defer proxyServer.Close(os.Interrupt)
+
+	req, err := http.NewRequest(http.MethodDelete, "http://"+proxyServer.Address+"/settings/device1", nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusForbidden, resp.StatusCode)
+	require.False(t, upstreamHit)
+}
+
+// TestProxyCapabilitiesReadDeniedRejectsWebSocket asserts Read: false
+// blocks the WebSocket upgrade — a WS subscription is a read operation
+// on this codebase, so it must be gated by canRead.
+func TestProxyCapabilitiesReadDeniedRejectsWebSocket(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+	remote := &ooo.Server{}
+	remote.Silence = true
+	remote.Start("localhost:0")
+	defer remote.Close(os.Interrupt)
+
+	proxyServer := &ooo.Server{}
+	proxyServer.Silence = true
+
+	err := proxy.Route(proxyServer, "settings/{deviceID}", proxy.Config{
+		Capabilities: &proxy.Capabilities{Read: false, Write: true, Delete: true},
+		Resolve: func(_ string) (string, string, error) {
+			return remote.Address, "settings", nil
+		},
+	})
+	require.NoError(t, err)
+	proxyServer.Start("localhost:0")
+	defer proxyServer.Close(os.Interrupt)
+
+	u := url.URL{Scheme: "ws", Host: proxyServer.Address, Path: "/settings/device1"}
+	c, resp, err := websocket.DefaultDialer.Dial(u.String(), nil)
+	require.Error(t, err)
+	if c != nil {
+		c.Close()
+	}
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusForbidden, resp.StatusCode)
+}
+
+// TestProxyCapabilitiesDefaultAllowsAll asserts nil Capabilities (the
+// default) permits all methods. Pinning this so a future "deny by
+// default" change is an explicit decision and not an accident.
+func TestProxyCapabilitiesDefaultAllowsAll(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+	remote := &ooo.Server{}
+	remote.Silence = true
+	remote.Start("localhost:0")
+	defer remote.Close(os.Interrupt)
+
+	proxyServer := &ooo.Server{}
+	proxyServer.Silence = true
+
+	err := proxy.Route(proxyServer, "settings/{deviceID}", proxy.Config{
+		Resolve: func(_ string) (string, string, error) {
+			return remote.Address, "settings", nil
+		},
+	})
+	require.NoError(t, err)
+	proxyServer.Start("localhost:0")
+	defer proxyServer.Close(os.Interrupt)
+
+	// POST
+	resp, err := http.Post("http://"+proxyServer.Address+"/settings/device1", "application/json", bytes.NewReader([]byte(`{"name":"x","value":1}`)))
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.NotEqual(t, http.StatusForbidden, resp.StatusCode)
+
+	// GET
+	resp, err = http.Get("http://" + proxyServer.Address + "/settings/device1")
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.NotEqual(t, http.StatusForbidden, resp.StatusCode)
+
+	// DELETE
+	req, err := http.NewRequest(http.MethodDelete, "http://"+proxyServer.Address+"/settings/device1", nil)
+	require.NoError(t, err)
+	resp, err = http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.NotEqual(t, http.StatusForbidden, resp.StatusCode)
+}
+
+// TestProxyCapabilitiesEnforcedViaNodeFilter pins that Capabilities
+// declared on a NodeFilterConfig is enforced by the underlying Route.
+// NodeFilter is a convenience wrapper around Route, so the enforcement
+// flows transitively — this test guards against a future refactor that
+// changes that delegation.
+func TestProxyCapabilitiesEnforcedViaNodeFilter(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+
+	var upstreamHit bool
+	upstream := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		upstreamHit = true
+	}))
+	defer upstream.Close()
+	upstreamHost := strings.TrimPrefix(upstream.URL, "http://")
+
+	host, portStr, err := net.SplitHostPort(upstreamHost)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portStr)
+	require.NoError(t, err)
+
+	directory := &ooo.Server{}
+	directory.Silence = true
+	directory.Start("localhost:0")
+	defer directory.Close(os.Interrupt)
+
+	nodeData, _ := json.Marshal(proxy.Node{IP: host, Port: port})
+	_, err = directory.Storage.Push("nodes/*", nodeData)
+	require.NoError(t, err)
+	nodes, err := ooo.GetList[proxy.Node](directory, "nodes/*")
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+	nodeID := nodes[0].Index
+
+	err = proxy.RouteNodeFilter(directory, proxy.NodeFilterConfig{
+		NodesKey:     "nodes/*",
+		LocalKey:     "states/*",
+		RemoteKey:    "state",
+		Capabilities: &proxy.Capabilities{Read: true, Write: false, Delete: true},
+	})
+	require.NoError(t, err)
+
+	resp, err := http.Post("http://"+directory.Address+"/states/"+nodeID, "application/json", bytes.NewReader([]byte(`{"x":1}`)))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusForbidden, resp.StatusCode)
+	require.False(t, upstreamHit, "upstream must not see denied requests via NodeFilter")
 }
 
 func TestProxyServerCloseTearsDownSubscriptions(t *testing.T) {

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -1490,6 +1490,108 @@ func TestProxyCapabilitiesEnforcedViaNodeFilter(t *testing.T) {
 	require.False(t, upstreamHit, "upstream must not see denied requests via NodeFilter")
 }
 
+// TestProxyCapabilitiesEnforcedViaRouteWithVars pins that Capabilities
+// declared on a Config passed to RouteWithVars is enforced — this
+// registrar uses mux path variables and a separate handler closure
+// from Route/RouteList, so it gets its own regression test.
+func TestProxyCapabilitiesEnforcedViaRouteWithVars(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+
+	var (
+		mu          sync.Mutex
+		upstreamHit bool
+	)
+	upstream := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		upstreamHit = true
+		mu.Unlock()
+	}))
+	defer upstream.Close()
+	upstreamHost := strings.TrimPrefix(upstream.URL, "http://")
+
+	proxyServer := &ooo.Server{}
+	proxyServer.Silence = true
+
+	// RouteWithVars assumes Router is already initialized. Use Start
+	// first to populate it (Start no-ops the listen on :0 closure
+	// timing, so we register routes after Start in this path).
+	proxyServer.Start("localhost:0")
+	err := proxy.RouteWithVars(proxyServer, "settings/{deviceID}", proxy.Config{
+		Capabilities: &proxy.Capabilities{Read: true, Write: false, Delete: true},
+		Resolve: func(_ string) (string, string, error) {
+			return upstreamHost, "", nil
+		},
+	})
+	require.NoError(t, err)
+	defer proxyServer.Close(os.Interrupt)
+
+	resp, err := http.Post("http://"+proxyServer.Address+"/settings/device1", "application/json", bytes.NewReader([]byte(`{"x":1}`)))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusForbidden, resp.StatusCode)
+	mu.Lock()
+	defer mu.Unlock()
+	require.False(t, upstreamHit, "upstream must not see denied requests via RouteWithVars")
+}
+
+// TestProxyCapabilitiesEnforcedViaNodeListFilter pins that Capabilities
+// declared on a NodeListFilterConfig is enforced by the underlying
+// RouteList. Mirrors TestProxyCapabilitiesEnforcedViaNodeFilter for
+// the list-shaped wrapper.
+func TestProxyCapabilitiesEnforcedViaNodeListFilter(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+
+	var (
+		mu          sync.Mutex
+		upstreamHit bool
+	)
+	upstream := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		upstreamHit = true
+		mu.Unlock()
+	}))
+	defer upstream.Close()
+	upstreamHost := strings.TrimPrefix(upstream.URL, "http://")
+
+	host, portStr, err := net.SplitHostPort(upstreamHost)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portStr)
+	require.NoError(t, err)
+
+	directory := &ooo.Server{}
+	directory.Silence = true
+	directory.Start("localhost:0")
+	defer directory.Close(os.Interrupt)
+
+	nodeData, _ := json.Marshal(proxy.Node{IP: host, Port: port})
+	_, err = directory.Storage.Push("nodes/*", nodeData)
+	require.NoError(t, err)
+	nodes, err := ooo.GetList[proxy.Node](directory, "nodes/*")
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+	nodeID := nodes[0].Index
+
+	err = proxy.RouteNodeListFilter(directory, proxy.NodeListFilterConfig{
+		NodesKey:     "nodes/*",
+		LocalKey:     "device/logs/*/*",
+		RemoteKey:    "logs/*",
+		Capabilities: &proxy.Capabilities{Read: true, Write: false, Delete: true},
+	})
+	require.NoError(t, err)
+
+	resp, err := http.Post("http://"+directory.Address+"/device/logs/"+nodeID+"/item1", "application/json", bytes.NewReader([]byte(`{"x":1}`)))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusForbidden, resp.StatusCode)
+	mu.Lock()
+	defer mu.Unlock()
+	require.False(t, upstreamHit, "upstream must not see denied requests via NodeListFilter")
+}
+
 func TestProxyServerCloseTearsDownSubscriptions(t *testing.T) {
 	var clientWg sync.WaitGroup
 	var mu sync.Mutex


### PR DESCRIPTION
Closes #86

## Summary
- Add `Config.enforceCapability(w, r)` and call it at the top of every proxy handler closure (`Route`, `RouteList`, `RouteWithVars`).
- 403 fires before `Resolve` and before any upstream contact; denied requests never reach the target.
- WebSocket upgrade requests gated by `Read`: clients get a clean HTTP 403 instead of a half-upgraded connection.
- `nil` Capabilities preserves default-allow-all semantics; `RouteNodeFilter`/`RouteNodeListFilter` enforce transitively via their delegation.

## Test plan
- [x] `go test ./proxy/ -race` — 7 new tests cover POST/PATCH/GET/DELETE denial, WS-gate-on-read, default-allows-all, and NodeFilter transitive enforcement. Failing-test premise verified: 5/6 deny tests fail pre-fix.
- [x] `go test ./...` with `-race` — full suite green.
- [x] Pre-flight self-review by a fresh sub-agent found one in-scope claim (NodeFilter not enforced); verified false (delegation works) and pinned with a regression test.

## Notes
HEAD/OPTIONS/PUT continue to return 405 on a denied route instead of 403 — they bypass `enforceCapability`'s switch and fall through to the existing default handler. Not a security bypass (no upstream contact), but a small semantic inconsistency worth a follow-up issue if anyone needs HEAD-as-Read or OPTIONS-preflight semantics.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)