### PR TITLE
fix(server): make Close idempotent under concurrent callers

### DIFF
--- a/ooo.go
+++ b/ooo.go
@@ -763,10 +763,15 @@ func (server *Server) Start(address string) {
 	}
 }
 
-// Close : shutdown the http server and database connection
+// Close : shutdown the http server and database connection.
+//
+// Safe to call from multiple goroutines: an atomic CompareAndSwap on
+// `closing` lets only the first caller through; concurrent callers
+// observe the in-progress shutdown and return immediately. The CAS is
+// load-bearing — a plain Load + Store guard would let two callers both
+// pass and both `close(server.clockStop)`, panicking the second.
 func (server *Server) Close(sig os.Signal) {
-	if atomic.LoadInt64(&server.closing) != 1 {
-		atomic.StoreInt64(&server.closing, 1)
+	if atomic.CompareAndSwapInt64(&server.closing, 0, 1) {
 		atomic.StoreInt64(&server.active, 0)
 		// Call pre-close cleanups first, before any stream/storage cleanup
 		server.preCloseCleanupsMu.Lock()

--- a/ooo_test.go
+++ b/ooo_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -22,6 +23,58 @@ func TestDoubleShutdown(t *testing.T) {
 	server.Start("localhost:0")
 	defer server.Close(os.Interrupt)
 	server.Close(os.Interrupt)
+}
+
+// TestConcurrentCloseDoesNotPanic asserts Server.Close is safe to call
+// from multiple goroutines simultaneously. Pre-fix the guard was a
+// non-atomic Load + Store of `closing`, so two concurrent callers both
+// observed the field == 0, both transitioned it to 1, and both
+// proceeded to `close(server.clockStop)` — the second close-of-closed
+// channel call panics. The fix is an atomic CompareAndSwap that lets
+// only the first caller in.
+//
+// This is a race-detector regression test. The Load+Store window
+// between the buggy guard and the close-of-channel is single-digit
+// nanoseconds, narrow enough that scheduling without -race
+// instrumentation rarely puts two goroutines in it on a fast CPU. The
+// fan-out + iteration loop maximizes the odds, but the reliable signal
+// is `go test -race`, which CI runs.
+func TestConcurrentCloseDoesNotPanic(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+	const (
+		iterations = 100
+		callers    = 32
+	)
+	for range iterations {
+		server := &Server{}
+		server.Silence = true
+		server.Start("localhost:0")
+
+		barrier := make(chan struct{})
+		var (
+			wg     sync.WaitGroup
+			panics atomic.Int64
+		)
+		wg.Add(callers)
+		for range callers {
+			go func() {
+				defer wg.Done()
+				defer func() {
+					if r := recover(); r != nil {
+						panics.Add(1)
+					}
+				}()
+				<-barrier
+				server.Close(os.Interrupt)
+			}()
+		}
+		close(barrier)
+		wg.Wait()
+		require.Zero(t, panics.Load(), "concurrent Server.Close must not panic")
+		require.False(t, server.Active(), "server must be inactive after Close")
+	}
 }
 
 func TestDoubleStart(t *testing.T) {


### PR DESCRIPTION
Closes #88

## Summary
- Replace the non-atomic `Load + Store` guard in `Server.Close` with `atomic.CompareAndSwapInt64`. Only the first caller enters the teardown branch; concurrent callers return as a no-op.
- Pre-fix the second caller raced through the guard and panicked on `close(server.clockStop)` (close-of-closed channel).

## Test plan
- [x] `TestConcurrentCloseDoesNotPanic` fans 32 goroutines × 100 iterations through `Close` behind a barrier and asserts no panic. Fails on the buggy code under `-race`; passes after the CAS.
- [x] Existing `TestDoubleShutdown` still passes (sequential double-Close).
- [x] `go test ./... -race` clean across the workspace.

## Notes
Pre-flight self-review surfaced the same `Load + Store` pattern in `StartWithError` on the `active` field. Same bug class, but `Start` is rarely fanned-in in practice, and fixing it here would expand scope beyond #88's "Close" framing. Flagged on the audit list as a separate item.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)