### PR TITLE
fix(storage): serialize Layered.Clear against concurrent writes

### DIFF
--- a/storage/layered.go
+++ b/storage/layered.go
@@ -717,8 +717,16 @@ func (l *Layered) DelSilent(path string) error {
 	return l.deleteBothLayers(path, &o)
 }
 
-// Clear removes all data from all layers
+// Clear removes all data from all layers.
+//
+// Takes the exclusive writeMutex so a concurrent Set cannot interleave
+// between the memory and embedded halves. Without that barrier, a Set
+// landing in the gap leaves the new value committed to memory while
+// embedded.Clear wipes embedded, diverging the two layers — same race
+// class as the glob-delete bug fixed in PR #79.
 func (l *Layered) Clear() {
+	l.writeMutex.Lock()
+	defer l.writeMutex.Unlock()
 	if l.memory != nil {
 		l.memory.Clear()
 	}

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1003,13 +1003,15 @@ func TestLayeredDelSilentGlobRollsBackOnEmbeddedFailure(t *testing.T) {
 	require.Len(t, items, 2, "rejected DelSilent glob must leave both keys visible in memory")
 }
 
-// syncEmbedded wraps a MemoryLayer and lets a test pause embedded.Del between
-// "Del started" and "Del executed" so a concurrent Set can race with the
-// in-progress glob delete deterministically.
+// syncEmbedded wraps a MemoryLayer and lets a test pause embedded.Del or
+// embedded.Clear between "started" and "executed" so a concurrent Set can
+// race with the in-progress write barrier deterministically.
 type syncEmbedded struct {
-	inner      *MemoryLayer
-	delStarted chan struct{}
-	delResume  chan struct{}
+	inner        *MemoryLayer
+	delStarted   chan struct{}
+	delResume    chan struct{}
+	clearStarted chan struct{}
+	clearResume  chan struct{}
 }
 
 func (s *syncEmbedded) Active() bool                      { return s.inner.Active() }
@@ -1033,7 +1035,18 @@ func (s *syncEmbedded) Del(k string) error {
 	return s.inner.Del(k)
 }
 func (s *syncEmbedded) Keys() ([]string, error) { return s.inner.Keys() }
-func (s *syncEmbedded) Clear()                  { s.inner.Clear() }
+func (s *syncEmbedded) Clear() {
+	if s.clearStarted != nil {
+		select {
+		case s.clearStarted <- struct{}{}:
+		default:
+		}
+	}
+	if s.clearResume != nil {
+		<-s.clearResume
+	}
+	s.inner.Clear()
+}
 func (s *syncEmbedded) Load() (map[string]*meta.Object, error) {
 	keys, err := s.inner.Keys()
 	if err != nil {
@@ -1120,6 +1133,85 @@ func TestLayeredDelGlobSerializesWithConcurrentSet(t *testing.T) {
 	embHas := len(embKeys) > 0
 	require.Equal(t, memHas, embHas,
 		"layers diverged: memory has key=%v, embedded has key=%v", memHas, embHas)
+}
+
+// TestLayeredClearSerializesWithConcurrentSet asserts Layered.Clear is
+// serialized against concurrent Sets via the same writeMutex that
+// Del(glob) takes. Pre-fix Clear called memory.Clear() then
+// embedded.Clear() with no write barrier — a Set that committed between
+// the two halves left memory holding the new value while embedded
+// remained empty, diverging the layers.
+//
+// Mirrors TestLayeredDelGlobSerializesWithConcurrentSet using the same
+// syncEmbedded hook, just on the Clear path.
+func TestLayeredClearSerializesWithConcurrentSet(t *testing.T) {
+	t.Parallel()
+
+	clearStarted := make(chan struct{}, 1)
+	clearResume := make(chan struct{})
+	embedded := &syncEmbedded{
+		inner:        NewMemoryLayer(),
+		clearStarted: clearStarted,
+		clearResume:  clearResume,
+	}
+	s := New(LayeredConfig{Memory: NewMemoryLayer(), Embedded: embedded})
+	// Unlike the Del-glob sibling, Clear emits no watcher event, so the
+	// "items/*" entry that test needs to mute delGlob's broadcast isn't
+	// required here. Set on "items/a" still needs to skip broadcast.
+	require.NoError(t, s.Start(Options{NoBroadcastKeys: []string{"items/a"}}))
+	defer s.Close()
+
+	// Drain watcher events so Set doesn't block on a 5s send timeout.
+	sharded := s.WatchSharded()
+	for i := range sharded.Count() {
+		shard := sharded.Shard(i)
+		go func() {
+			for range shard {
+			}
+		}()
+	}
+
+	// Start Clear. memory.Clear() runs synchronously; embedded.Clear blocks
+	// at the hook so a Set can race the "between halves" window.
+	clearDone := make(chan struct{})
+	go func() {
+		s.Clear()
+		close(clearDone)
+	}()
+	<-clearStarted
+
+	// Attempt a Set while Clear is mid-flight. With the fix, Set takes the
+	// shared writeMutex and must wait for the exclusive lock Clear holds.
+	setStarted := make(chan struct{})
+	setDone := make(chan error, 1)
+	go func() {
+		close(setStarted)
+		_, err := s.Set("items/a", json.RawMessage(`{"v":1}`))
+		setDone <- err
+	}()
+	<-setStarted
+
+	// Set must be blocked: should not finish while Clear is still paused.
+	select {
+	case err := <-setDone:
+		t.Fatalf("Set must wait for Clear: unexpected early completion err=%v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(clearResume)
+	<-clearDone
+	require.NoError(t, <-setDone)
+
+	// After both finish: layers must agree on whether items/a exists.
+	memItems, err := s.GetList("items/*")
+	require.NoError(t, err)
+	embKeys, err := embedded.inner.Keys()
+	require.NoError(t, err)
+
+	memHas := len(memItems) > 0
+	embHas := len(embKeys) > 0
+	require.Equal(t, memHas, embHas,
+		"layers diverged after concurrent Clear+Set: memory has key=%v, embedded has key=%v", memHas, embHas)
 }
 
 // TestShardedChanDropIsObservable asserts that a send-timeout drop exposes


### PR DESCRIPTION
Closes #90

## Summary
- Wrap `Layered.Clear` in `writeMutex.Lock` so a concurrent `Set` cannot interleave between the memory and embedded halves.
- Same race class as the glob-delete bug fixed in PR #79; same fix shape — Clear joins Del(glob)/DelSilent(glob) on the exclusive lock; Set/Push/Patch continue to take the shared lock and now block while Clear runs.

## Test plan
- [x] `TestLayeredClearSerializesWithConcurrentSet` pauses `embedded.Clear` via the `syncEmbedded` hook, races a `Set` against it, asserts the Set blocks until Clear completes, then asserts both layers agree on whether the key exists. Failing-test premise verified: pre-fix the Set commits early and divergence is observable; post-fix the test passes.
- [x] `go test ./... -race` clean across the workspace.

## Notes
Pre-flight self-review by a fresh sub-agent flagged two deferred items: `Clear` emits no watcher event (pre-existing behavior — subscribers don't observe a Clear), and the `syncEmbedded` hook pattern is duplicated per op. Both are out of scope for a race fix.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)