### PR TITLE
fix(stream): prune empty non-persistent pools so churned paths don't leak

### DIFF
--- a/filters.go
+++ b/filters.go
@@ -83,10 +83,20 @@ func (server *Server) AfterWriteFilter(path string, apply Notify, cfg ...FilterC
 	server.filters.AddAfterWrite(path, apply, cfg...)
 }
 
+// markPoolPersistent tags the stream pool for path as persistent so
+// the empty-pool sweep cannot prune it when the last subscriber
+// disconnects. Read-side filter registrations after Start use this;
+// for registrations before Start the bulk PreallocatePools call
+// inside StartWithError covers them.
+func (server *Server) markPoolPersistent(path string) {
+	server.Stream.MarkPersistent(path)
+}
+
 // ReadObjectFilter add a filter for single meta.Object reads
 func (server *Server) ReadObjectFilter(path string, apply ApplyObject, cfg ...FilterConfig) {
 	checkReservedPath(path)
 	server.filters.AddReadObject(path, apply, cfg...)
+	server.markPoolPersistent(path)
 }
 
 // ReadListFilter add a filter for []meta.Object reads.
@@ -95,6 +105,7 @@ func (server *Server) ReadObjectFilter(path string, apply ApplyObject, cfg ...Fi
 func (server *Server) ReadListFilter(path string, apply ApplyList, cfg ...FilterConfig) {
 	checkReservedPath(path)
 	server.filters.AddReadList(path, apply, cfg...)
+	server.markPoolPersistent(path)
 }
 
 // OpenFilter open noop read and write filters
@@ -110,6 +121,7 @@ func (server *Server) OpenFilter(name string, cfg ...FilterConfig) {
 	} else {
 		server.filters.AddReadObject(name, NoopObjectFilter, cfg...)
 	}
+	server.markPoolPersistent(name)
 }
 
 // LimitFilter creates a limit filter for a glob pattern path that maintains
@@ -137,6 +149,7 @@ func (server *Server) registerLimitFilter(path string, lf *filters.LimitFilter, 
 
 	// ReadListFilter ensures clients never see more than the configured constraints
 	server.filters.AddReadList(path, lf.ReadListFilter, cfg...)
+	server.markPoolPersistent(path)
 
 	// Also allow reading individual items that match the glob pattern
 	server.filters.AddReadObject(path, NoopObjectFilter, cfg...)

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -37,9 +37,14 @@ type Conn struct {
 
 // Pool of key filtered connections
 type Pool struct {
-	mutex       sync.RWMutex
-	Key         string
-	cache       Cache
+	mutex sync.RWMutex
+	Key   string
+	cache Cache
+	// persistent pools (currently those pre-allocated from filter paths)
+	// are never pruned by the empty-pool sweep. Pruning is triggered when
+	// the last conn closes; persistent pools opt out of that so they
+	// stay ready for the next subscriber without an allocation.
+	persistent  bool
 	connections []*Conn
 }
 
@@ -180,12 +185,85 @@ func (sm *Stream) PreallocatePools(paths []string) {
 		if _, exists := sm.pools[path]; !exists {
 			pool := &Pool{
 				Key:         path,
+				persistent:  true,
 				connections: make([]*Conn, 0, 4),
 			}
 			sm.pools[path] = pool
 			sm.poolIndex.insert(path, pool)
 		}
 	}
+}
+
+// PoolCount returns the number of registered pools (excluding the
+// clock pool). Intended for tests and operational introspection — a
+// steady-state value near the count of preallocated paths confirms
+// the empty-pool sweep is reclaiming churned subscription paths.
+func (sm *Stream) PoolCount() int {
+	sm.mutex.RLock()
+	defer sm.mutex.RUnlock()
+	return len(sm.pools)
+}
+
+// MarkPersistent ensures the pool for key exists and is exempt from
+// the empty-pool sweep. Read-side filter registrations
+// (ReadObjectFilter, ReadListFilter, OpenFilter, LimitFilter) call
+// through to this after Start so a path that documents itself as
+// subscribable keeps its pool ready across transient drops to zero
+// subscribers. Paths without a read filter remain prunable so
+// churned dynamic subscription paths cannot accumulate.
+//
+// The persistent flag is written under pool.mutex so Close's read of
+// the same flag is race-free.
+func (sm *Stream) MarkPersistent(key string) {
+	if key == "" {
+		return
+	}
+	sm.mutex.Lock()
+	defer sm.mutex.Unlock()
+	if sm.pools == nil {
+		sm.pools = make(map[string]*Pool)
+	}
+	if sm.poolIndex == nil {
+		sm.poolIndex = newPoolTrie()
+	}
+	if pool, exists := sm.pools[key]; exists {
+		pool.mutex.Lock()
+		pool.persistent = true
+		pool.mutex.Unlock()
+		return
+	}
+	pool := &Pool{
+		Key:         key,
+		persistent:  true,
+		connections: make([]*Conn, 0, 4),
+	}
+	sm.pools[key] = pool
+	sm.poolIndex.insert(key, pool)
+}
+
+// PruneIfEmpty drops a non-persistent pool whose connection list is
+// empty. Used by external cleanup paths (e.g., a WebSocket upgrade
+// that fails after fetch already created the pool via InitCache) so
+// an orphan pool cannot leak when the connection that was supposed
+// to claim it never arrives. Close uses the same predicate inline.
+func (sm *Stream) PruneIfEmpty(key string) {
+	if key == "" {
+		return
+	}
+	sm.mutex.Lock()
+	defer sm.mutex.Unlock()
+	pool, exists := sm.pools[key]
+	if !exists {
+		return
+	}
+	pool.mutex.RLock()
+	disposable := !pool.persistent && len(pool.connections) == 0
+	pool.mutex.RUnlock()
+	if !disposable {
+		return
+	}
+	delete(sm.pools, key)
+	sm.poolIndex.remove(key)
 }
 
 // New creates a WebSocket connection and sends the initial snapshot
@@ -326,7 +404,14 @@ func removeConn(conns []*Conn, client *Conn) []*Conn {
 	return conns
 }
 
-// Close client connection
+// Close client connection.
+//
+// After removing the connection, a non-persistent pool whose
+// connection list has drained to empty is removed from sm.pools and
+// the poolIndex trie so churned subscription paths cannot accumulate
+// forever. Persistent pools (those pre-allocated via
+// PreallocatePools for known filter paths) survive the sweep so the
+// next subscriber can reuse them.
 func (sm *Stream) Close(key string, client *Conn) {
 	sm.mutex.Lock()
 	if key == "" {
@@ -340,7 +425,12 @@ func (sm *Stream) Close(key string, client *Conn) {
 		if pool != nil {
 			pool.mutex.Lock()
 			pool.connections = removeConn(pool.connections, client)
+			emptyAndDisposable := !pool.persistent && len(pool.connections) == 0
 			pool.mutex.Unlock()
+			if emptyAndDisposable {
+				delete(sm.pools, key)
+				sm.poolIndex.remove(key)
+			}
 		}
 	}
 	sm.mutex.Unlock()

--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -2,6 +2,7 @@ package stream
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -66,9 +67,11 @@ func TestInitCacheObject(t *testing.T) {
 	require.Equal(t, version, cacheVersion)
 
 	stream.Close(testKey, wsConn)
-	require.Equal(t, 1, len(stream.pools))
-	require.Equal(t, testKey, stream.pools[testKey].Key)
-	require.Equal(t, 0, len(stream.pools[testKey].connections))
+	// Non-persistent pool with no remaining conns is pruned from
+	// sm.pools and the poolIndex trie — the empty-pool sweep added
+	// alongside the pruning audit fix.
+	require.Equal(t, 0, len(stream.pools))
+	require.Nil(t, stream.pools[testKey])
 }
 
 func TestConcurrentBroadcast(t *testing.T) {
@@ -158,9 +161,8 @@ func TestConcurrentBroadcast(t *testing.T) {
 	stream.Close("root", wsConn)
 	stream.Close("a", wsConnA)
 	stream.Close("b", wsConnB)
-	require.Equal(t, 3, len(stream.pools))
-	require.Equal(t, 0, len(stream.pools["root"].connections))
-	require.Equal(t, 0, len(stream.pools["a"].connections))
+	// Non-persistent pools are pruned when their last conn closes.
+	require.Equal(t, 0, len(stream.pools))
 }
 
 func TestRemoveConn(t *testing.T) {
@@ -213,6 +215,75 @@ func TestInitClock(t *testing.T) {
 	// Call again to ensure idempotency
 	stream.InitClock()
 	require.NotNil(t, stream.clockPool)
+}
+
+// TestEmptyPoolsPrunedOnClose asserts that after the last connection
+// disconnects, a non-persistent pool is removed from sm.pools AND from
+// the poolIndex trie. Pre-fix `sm.pools[key]` and `poolIndex` grew on
+// every distinct subscribed key with no pruning when the pool
+// emptied, so churned subscription paths leaked one entry per
+// subscribe-then-disconnect cycle.
+func TestEmptyPoolsPrunedOnClose(t *testing.T) {
+	monotonic.Init()
+	stream := Stream{
+		Console:   coat.NewConsole(domain, true),
+		pools:     make(map[string]*Pool),
+		poolIndex: newPoolTrie(),
+		OnSubscribe: func(string) error {
+			return nil
+		},
+		OnUnsubscribe: func(string) {},
+	}
+
+	const subscriptions = 50
+	conns := make([]*Conn, 0, subscriptions)
+	keys := make([]string, 0, subscriptions)
+	for i := range subscriptions {
+		key := fmt.Sprintf("ephemeral/%d", i)
+		req, w := makeStreamRequestMock(domain + "/" + key)
+		c, err := stream.New(key, w, req, nil, 0)
+		require.NoError(t, err)
+		conns = append(conns, c)
+		keys = append(keys, key)
+	}
+	require.Equal(t, subscriptions, stream.PoolCount(),
+		"setup: every subscription must register a pool")
+	require.Equal(t, subscriptions, stream.poolIndex.size(),
+		"setup: every subscription must register in the trie")
+
+	for i, c := range conns {
+		stream.Close(keys[i], c)
+	}
+
+	require.Equal(t, 0, stream.PoolCount(),
+		"every non-persistent pool must be reclaimed once its last conn closes")
+	require.Equal(t, 0, stream.poolIndex.size(),
+		"trie must reclaim the corresponding entries")
+}
+
+// TestPersistentPoolsSurviveCloseSweep asserts that pre-allocated pools
+// (created via PreallocatePools for known filter paths) are NOT pruned
+// even when their connection count drops to zero. Those pools are
+// kept ready for the next subscriber to avoid re-allocation.
+func TestPersistentPoolsSurviveCloseSweep(t *testing.T) {
+	monotonic.Init()
+	stream := Stream{
+		Console:       coat.NewConsole(domain, true),
+		OnSubscribe:   func(string) error { return nil },
+		OnUnsubscribe: func(string) {},
+	}
+
+	stream.PreallocatePools([]string{"items/*", "users/*"})
+	require.Equal(t, 2, stream.PoolCount(), "setup: preallocated pools must register")
+
+	req, w := makeStreamRequestMock(domain + "/items/*")
+	c, err := stream.New("items/*", w, req, nil, 0)
+	require.NoError(t, err)
+
+	stream.Close("items/*", c)
+
+	require.Equal(t, 2, stream.PoolCount(),
+		"persistent pools must survive empty-conn sweep")
 }
 
 func TestPreallocatePools(t *testing.T) {

--- a/ws.go
+++ b/ws.go
@@ -51,6 +51,11 @@ func (server *Server) ws(w http.ResponseWriter, r *http.Request) error {
 	// This prevents the race condition where broadcasts could arrive before the initial snapshot
 	client, err := server.Stream.New(_key, w, r, initialData, result.Version)
 	if err != nil {
+		// fetch above called InitCache, which creates the pool eagerly.
+		// If the WebSocket upgrade (or post-upgrade snapshot write)
+		// fails, no Close path will run to release that pool — explicit
+		// prune here keeps the empty-pool sweep contract intact.
+		server.Stream.PruneIfEmpty(_key)
 		if errors.Is(err, stream.ErrHijacked) {
 			server.Console.Err("ooo: websocket closed during init", err)
 		} else {

--- a/ws_test.go
+++ b/ws_test.go
@@ -234,6 +234,36 @@ func TestWebSocketSubscriptionEvents(t *testing.T) {
 	require.Equal(t, "testkey", unsubscribed)
 }
 
+// TestFetchUpgradeFailDoesNotLeakPool asserts that when a subscription
+// request reaches the ws handler — populating the stream pool's cache
+// via fetch — and the subsequent WebSocket upgrade fails, the pool is
+// pruned so an orphan entry cannot linger in sm.pools / poolIndex.
+// Pre-fix InitCache eagerly registered the pool and a failed upgrade
+// never invoked Close, so the entry leaked forever for any
+// non-persistent (filter-less) subscription path.
+func TestFetchUpgradeFailDoesNotLeakPool(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+	server := Server{}
+	server.Silence = true
+	server.AllowedOrigins = []string{"http://allowed.example.com"}
+	server.Start("localhost:0")
+	defer server.Close(os.Interrupt)
+
+	require.Zero(t, server.Stream.PoolCount(), "fixture: no filters registered, no pools expected")
+
+	u := url.URL{Scheme: "ws", Host: server.Address, Path: "/ephemeral"}
+	hdr := http.Header{}
+	hdr.Set("Origin", "http://evil.example.com")
+	c, _, err := websocket.DefaultDialer.Dial(u.String(), hdr)
+	require.Error(t, err, "cross-origin upgrade must be rejected")
+	require.Nil(t, c)
+
+	require.Zero(t, server.Stream.PoolCount(),
+		"the orphan pool from a failed upgrade must be pruned by PruneIfEmpty")
+}
+
 // TestWebSocketCheckOriginRejectsCrossOrigin asserts the WebSocket upgrader
 // rejects connections whose Origin is not in the server's AllowedOrigins.
 // Pre-fix the upgrader's CheckOrigin was a no-op (returned true whenever the


### PR DESCRIPTION
Closes #96

## Summary
- `Stream.Close` prunes a non-persistent pool from `sm.pools` and the `poolIndex` trie once its connection list drains to empty.
- New `Pool.persistent` flag protects pools preallocated for registered filter paths; post-Start read-side filter registrations (`ReadObjectFilter`, `ReadListFilter`, `OpenFilter`, `LimitFilter`) call into `Stream.MarkPersistent`.
- New `Stream.PruneIfEmpty` covers the fetch→failed-upgrade orphan case: ws handler calls it when `Stream.New` errors so the pool created by `InitCache` does not linger.
- `Stream.PoolCount` for observability.

## Test plan
- [x] `TestEmptyPoolsPrunedOnClose` — 50 distinct dynamic paths return to 0 registry entries.
- [x] `TestPersistentPoolsSurviveCloseSweep` — preallocated pools survive the sweep.
- [x] `TestFetchUpgradeFailDoesNotLeakPool` — failed cross-origin upgrade leaves no orphan pool.
- [x] `TestInitCacheObject`/`TestConcurrentBroadcast` updated to reflect prune-on-empty semantics; existing reconnect-with-version test (`TestWebSocketWithVersion`) still passes because its path has a filter and is therefore persistent.
- [x] `go test ./... -race` clean across the workspace.

## Notes
Pre-flight self-review caught three blockers, all fixed before this PR opened:
- Data race on `pool.persistent` between `MarkPersistent` (writer) and `Close` (reader) — `MarkPersistent` now takes `pool.mutex` around the flag flip.
- Orphan-pool leak when fetch populates the pool and the upgrade fails — `Stream.PruneIfEmpty` + ws.go cleanup.
- Orphaned godoc on `ReadObjectFilter` — comment moved back.

Doc/code alignment: only read-side filter helpers mark persistent. Write/Delete/AfterWrite helpers intentionally leave the pool prunable — a path with no read filter cannot be subscribed in Static mode, and in non-Static mode the pool is created on demand. The `MarkPersistent` docstring now reflects this.

Tangentially aware non-blocker: `broadcastPool`'s failed-conn removal does not directly trigger prune; the read-loop's subsequent `Stream.Close` does. Eventually consistent. Documented as a possible future tightening; not addressed here.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)