### PR TITLE
fix(server): switch routeOracleMu to sync.RWMutex on the hot path

### DIFF
--- a/ooo.go
+++ b/ooo.go
@@ -130,7 +130,7 @@ type Server struct {
 	endpoints          []ui.EndpointInfo          // registered custom endpoints
 	proxies            []ui.ProxyInfo             // registered proxy routes
 	routeOracle        *mux.Router                // mirrors Endpoint/Proxy paths so the data wildcard can defer to them
-	routeOracleMu      sync.Mutex                 // serializes oracle registrations and matches
+	routeOracleMu      sync.RWMutex               // protects routeOracle; readers (routeOracleSkip) take RLock on the data-wildcard hot path, registrations take Lock
 	proxyCleanups      []func()                   // cleanup functions for proxy subscriptions
 	proxyCleanupMu     sync.Mutex                 // protects proxyCleanups
 	NoBroadcastKeys    []string
@@ -718,9 +718,14 @@ func (server *Server) setupRoutes() {
 // routeOracleSkip returns true if the request does NOT match any registered
 // Endpoint or Proxy route. It is wired as a MatcherFunc on the data wildcard
 // so explicit routes take precedence regardless of registration order.
+//
+// Takes RLock on the routeOracle so concurrent data-wildcard requests can
+// run their oracle check in parallel; RegisterOracleRoute takes the
+// write Lock. The mux.Router's Match method is documented as safe for
+// concurrent read use once the route set is established.
 func (server *Server) routeOracleSkip(r *http.Request, _ *mux.RouteMatch) bool {
-	server.routeOracleMu.Lock()
-	defer server.routeOracleMu.Unlock()
+	server.routeOracleMu.RLock()
+	defer server.routeOracleMu.RUnlock()
 	if server.routeOracle == nil {
 		return true
 	}

--- a/ooo_test.go
+++ b/ooo_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/benitogf/go-json"
 	"github.com/benitogf/ooo/storage"
+	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/require"
 )
 
@@ -76,6 +77,74 @@ func TestConcurrentCloseDoesNotPanic(t *testing.T) {
 		require.Zero(t, panics.Load(), "concurrent Server.Close must not panic")
 		require.False(t, server.Active(), "server must be inactive after Close")
 	}
+}
+
+// TestRouteOracleSkipAllowsConcurrentMatches asserts the data
+// wildcard's oracle-check is parallelizable across concurrent
+// requests. Pre-fix routeOracleMu was a plain sync.Mutex held
+// around every call to routeOracle.Match, so a single oracle hit
+// queue-blocked every other in-flight request through the same
+// matcher. The fix switches to sync.RWMutex with RLock on the hot
+// path; registrations still hold the write lock.
+//
+// The test injects a custom MatcherFunc on the oracle that records
+// the maximum number of concurrent entries to the matcher. Pre-fix
+// the maximum is 1 (full serialization). Post-fix it climbs above 1
+// when multiple goroutines call routeOracleSkip simultaneously.
+func TestRouteOracleSkipAllowsConcurrentMatches(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+
+	server := &Server{}
+	server.Silence = true
+	server.Start("localhost:0")
+	defer server.Close(os.Interrupt)
+
+	var (
+		concurrent atomic.Int64
+		maxSeen    atomic.Int64
+	)
+	probe := mux.MatcherFunc(func(_ *http.Request, _ *mux.RouteMatch) bool {
+		cur := concurrent.Add(1)
+		defer concurrent.Add(-1)
+		for {
+			prev := maxSeen.Load()
+			if cur <= prev || maxSeen.CompareAndSwap(prev, cur) {
+				break
+			}
+		}
+		// Brief pause widens the contention window so concurrent
+		// callers can overlap inside the matcher without flaking on
+		// fast schedulers.
+		time.Sleep(2 * time.Millisecond)
+		return false // not a match — let the data wildcard take over
+	})
+	server.routeOracleMu.Lock()
+	if server.routeOracle == nil {
+		server.routeOracle = mux.NewRouter()
+	}
+	server.routeOracle.HandleFunc("/{key}", func(http.ResponseWriter, *http.Request) {}).MatcherFunc(probe)
+	server.routeOracleMu.Unlock()
+
+	const callers = 16
+	barrier := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(callers)
+	for range callers {
+		go func() {
+			defer wg.Done()
+			req := httptest.NewRequest(http.MethodGet, "/anykey", nil)
+			var m mux.RouteMatch
+			<-barrier
+			_ = server.routeOracleSkip(req, &m)
+		}()
+	}
+	close(barrier)
+	wg.Wait()
+
+	require.Greater(t, maxSeen.Load(), int64(1),
+		"routeOracle matching must allow concurrent readers; max concurrent observed = %d", maxSeen.Load())
 }
 
 func TestDoubleStart(t *testing.T) {


### PR DESCRIPTION
Closes #98

## Summary
- `routeOracleMu` becomes `sync.RWMutex`. `routeOracleSkip` takes `RLock` on the data-wildcard hot path so concurrent requests run their oracle check in parallel.
- `RegisterOracleRoute` continues to hold the exclusive `Lock` — registrations remain mutually exclusive with each other and with in-flight matchers.

## Test plan
- [x] `TestRouteOracleSkipAllowsConcurrentMatches` — injects a slow probe `MatcherFunc` on the oracle, fans 16 goroutines through `routeOracleSkip` behind a barrier, asserts the max-observed concurrent entries > 1. Pre-fix the assertion fires with max == 1 (full serialization); post-fix it climbs above 1.
- [x] `go test ./... -race` clean across the workspace.

## Notes
Pre-flight self-review by a fresh sub-agent — clean (no blockers, no in-scope non-blockers). One deferred follow-up noted: the pre-existing lazy-init of `routeOracle` in `defaults()` runs without `routeOracleMu`, leaving an unrelated narrow startup window. Not introduced by this diff (pre-existing under `sync.Mutex` too); flagged as a follow-up.

`gorilla/mux.Router.Match` is documented as safe for concurrent read use once routes are registered — verified against the upstream source.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)