### PR TITLE
fix(server): gate custom Endpoints and Proxy routes with Server.Audit

### DIFF
--- a/audit_test.go
+++ b/audit_test.go
@@ -15,6 +15,42 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestAuditGatesEndpoint asserts that a custom Endpoint registered
+// via Server.Endpoint honors Server.Audit. Pre-fix the endpoint
+// handler was registered directly on Router with no Audit wrapping,
+// so a deny-everything Audit had no effect — custom endpoint paths
+// silently bypassed auth/rate-limiting/observability gates that
+// every REST handler already respects.
+func TestAuditGatesEndpoint(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+	server := ooo.Server{}
+	server.Silence = true
+	server.Audit = func(r *http.Request) bool { return false }
+	server.Start("localhost:0")
+	defer server.Close(os.Interrupt)
+
+	var handlerRan bool
+	server.Endpoint(ooo.EndpointConfig{
+		Path: "/custom",
+		Methods: ooo.Methods{
+			http.MethodGet: {Response: nil},
+		},
+		Handler: func(w http.ResponseWriter, _ *http.Request) {
+			handlerRan = true
+			w.WriteHeader(http.StatusOK)
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/custom", nil)
+	w := httptest.NewRecorder()
+	server.Router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusUnauthorized, w.Result().StatusCode,
+		"Audit returning false must reject custom Endpoint requests")
+	require.False(t, handlerRan, "Endpoint handler must not run when Audit denies")
+}
+
 func TestAudit(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Parallel()

--- a/endpoint.go
+++ b/endpoint.go
@@ -1,6 +1,7 @@
 package ooo
 
 import (
+	"fmt"
 	"net/http"
 	"reflect"
 	"regexp"
@@ -171,6 +172,26 @@ func defaultValue(t reflect.Type) any {
 	}
 }
 
+// AuditHandler wraps next so the configured Server.Audit gate runs
+// before the handler. Returns 401 Unauthorized when Audit denies the
+// request. Used by Endpoint registration and the proxy package so
+// custom routes participate in the same auth/rate-limit/observability
+// path as the built-in REST handlers.
+//
+// The nil-Audit branch is defensive for direct-Router test paths
+// (ServeHTTP bypassing Start). Production callers reach this wrapper
+// only after Start has populated the default Audit via defaults().
+func (server *Server) AuditHandler(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if server.Audit != nil && !server.Audit(r) {
+			w.WriteHeader(http.StatusUnauthorized)
+			fmt.Fprintf(w, "%s", ErrNotAuthorized)
+			return
+		}
+		next(w, r)
+	}
+}
+
 // Endpoint registers a custom HTTP endpoint with metadata for UI visibility
 func (server *Server) Endpoint(cfg EndpointConfig) {
 	methods := make([]string, 0, len(cfg.Methods))
@@ -196,8 +217,10 @@ func (server *Server) Endpoint(cfg EndpointConfig) {
 	}
 
 	// Register route with router and mirror onto the route oracle so the
-	// data wildcard defers to this Endpoint regardless of registration order.
-	server.Router.HandleFunc(cfg.Path, cfg.Handler).Methods(methods...)
+	// data wildcard defers to this Endpoint regardless of registration
+	// order. Wrap the handler in AuditHandler so Server.Audit gates the
+	// custom path the same way it gates the built-in REST handlers.
+	server.Router.HandleFunc(cfg.Path, server.AuditHandler(cfg.Handler)).Methods(methods...)
 	server.RegisterOracleRoute(cfg.Path, methods)
 
 	// Track for UI

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -521,7 +521,10 @@ func Route(server *ooo.Server, localPath string, cfg Config) error {
 
 	// Register the route and mirror onto the route oracle so the data
 	// wildcard defers to this proxy regardless of registration order.
-	server.Router.HandleFunc("/"+muxPattern, handler)
+	// AuditHandler runs Server.Audit before the proxy handler so
+	// proxied paths participate in the same auth gate as built-in
+	// REST handlers.
+	server.Router.HandleFunc("/"+muxPattern, server.AuditHandler(handler))
 	server.RegisterOracleRoute("/"+muxPattern, nil)
 
 	// Register for UI visibility
@@ -616,9 +619,10 @@ func RouteList(server *ooo.Server, localPath string, cfg Config) error {
 
 	// Register routes - specific path first, then base. Mirror both onto
 	// the route oracle so the data wildcard defers to them regardless of
-	// registration order.
-	server.Router.HandleFunc("/"+muxPattern, itemHandler)
-	server.Router.HandleFunc("/"+basePath, listHandler)
+	// registration order. AuditHandler wraps each so Server.Audit gates
+	// proxied requests the same way it gates built-in REST handlers.
+	server.Router.HandleFunc("/"+muxPattern, server.AuditHandler(itemHandler))
+	server.Router.HandleFunc("/"+basePath, server.AuditHandler(listHandler))
 	server.RegisterOracleRoute("/"+muxPattern, nil)
 	server.RegisterOracleRoute("/"+basePath, nil)
 
@@ -873,7 +877,7 @@ func RouteWithVars(server *ooo.Server, localPath string, cfg Config) error {
 		handleHTTPProxy(server, w, r, address, remotePath, cfg.Subscribe)
 	}
 
-	server.Router.HandleFunc("/"+localPath, handler)
+	server.Router.HandleFunc("/"+localPath, server.AuditHandler(handler))
 	server.RegisterOracleRoute("/"+localPath, nil)
 
 	// Register for UI visibility

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1590,6 +1591,120 @@ func TestProxyCapabilitiesEnforcedViaNodeListFilter(t *testing.T) {
 	mu.Lock()
 	defer mu.Unlock()
 	require.False(t, upstreamHit, "upstream must not see denied requests via NodeListFilter")
+}
+
+// TestProxyAuditGatesRoute asserts that a proxied request through
+// Route honors Server.Audit. Pre-fix proxy handlers were registered
+// directly on Router with no Audit wrapping, so a deny-everything
+// Audit had no effect — custom proxy paths silently bypassed
+// auth/rate-limiting/observability gates.
+func TestProxyAuditGatesRoute(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+
+	var upstreamHit atomic.Bool
+	upstream := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		upstreamHit.Store(true)
+	}))
+	defer upstream.Close()
+	upstreamHost := strings.TrimPrefix(upstream.URL, "http://")
+
+	proxyServer := &ooo.Server{}
+	proxyServer.Silence = true
+	proxyServer.Audit = func(r *http.Request) bool { return false }
+
+	err := proxy.Route(proxyServer, "settings/{deviceID}", proxy.Config{
+		Resolve: func(_ string) (string, string, error) {
+			return upstreamHost, "", nil
+		},
+	})
+	require.NoError(t, err)
+	proxyServer.Start("localhost:0")
+	defer proxyServer.Close(os.Interrupt)
+
+	resp, err := http.Get("http://" + proxyServer.Address + "/settings/device1")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode,
+		"Audit returning false must reject proxied Route requests")
+	require.False(t, upstreamHit.Load(), "upstream must not be contacted when Audit denies")
+}
+
+// TestProxyAuditGatesRouteList asserts the same for the list-shaped
+// registrar (covers both base and item handler closures).
+func TestProxyAuditGatesRouteList(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+
+	var upstreamHit atomic.Bool
+	upstream := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		upstreamHit.Store(true)
+	}))
+	defer upstream.Close()
+	upstreamHost := strings.TrimPrefix(upstream.URL, "http://")
+
+	proxyServer := &ooo.Server{}
+	proxyServer.Silence = true
+	proxyServer.Audit = func(r *http.Request) bool { return false }
+
+	err := proxy.RouteList(proxyServer, "devices/{deviceID}/things/{itemID}", proxy.Config{
+		Resolve: func(_ string) (string, string, error) {
+			return upstreamHost, "", nil
+		},
+	})
+	require.NoError(t, err)
+	proxyServer.Start("localhost:0")
+	defer proxyServer.Close(os.Interrupt)
+
+	// Item path.
+	resp, err := http.Get("http://" + proxyServer.Address + "/devices/d1/things/i1")
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+	// Base path.
+	resp, err = http.Get("http://" + proxyServer.Address + "/devices/d1/things")
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+	require.False(t, upstreamHit.Load(), "upstream must not be contacted when Audit denies")
+}
+
+// TestProxyAuditGatesRouteWithVars asserts the same for RouteWithVars.
+func TestProxyAuditGatesRouteWithVars(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+
+	var upstreamHit atomic.Bool
+	upstream := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		upstreamHit.Store(true)
+	}))
+	defer upstream.Close()
+	upstreamHost := strings.TrimPrefix(upstream.URL, "http://")
+
+	proxyServer := &ooo.Server{}
+	proxyServer.Silence = true
+	proxyServer.Audit = func(r *http.Request) bool { return false }
+	// RouteWithVars assumes Router is initialized.
+	proxyServer.Start("localhost:0")
+	defer proxyServer.Close(os.Interrupt)
+
+	err := proxy.RouteWithVars(proxyServer, "settings/{deviceID}", proxy.Config{
+		Resolve: func(_ string) (string, string, error) {
+			return upstreamHost, "", nil
+		},
+	})
+	require.NoError(t, err)
+
+	resp, err := http.Get("http://" + proxyServer.Address + "/settings/device1")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	require.False(t, upstreamHit.Load())
 }
 
 func TestProxyServerCloseTearsDownSubscriptions(t *testing.T) {

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -1632,7 +1632,11 @@ func TestProxyAuditGatesRoute(t *testing.T) {
 }
 
 // TestProxyAuditGatesRouteList asserts the same for the list-shaped
-// registrar (covers both base and item handler closures).
+// registrar — exercises BOTH closures it installs: itemHandler at the
+// glob-expanded path and listHandler at the trimmed base path. A
+// glob-suffix localPath ("items/*") is required so basePath strips to
+// "items" and the request to /items actually matches the listHandler
+// route instead of falling through to the data wildcard.
 func TestProxyAuditGatesRouteList(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Parallel()
@@ -1649,7 +1653,7 @@ func TestProxyAuditGatesRouteList(t *testing.T) {
 	proxyServer.Silence = true
 	proxyServer.Audit = func(r *http.Request) bool { return false }
 
-	err := proxy.RouteList(proxyServer, "devices/{deviceID}/things/{itemID}", proxy.Config{
+	err := proxy.RouteList(proxyServer, "items/*", proxy.Config{
 		Resolve: func(_ string) (string, string, error) {
 			return upstreamHost, "", nil
 		},
@@ -1658,19 +1662,68 @@ func TestProxyAuditGatesRouteList(t *testing.T) {
 	proxyServer.Start("localhost:0")
 	defer proxyServer.Close(os.Interrupt)
 
-	// Item path.
-	resp, err := http.Get("http://" + proxyServer.Address + "/devices/d1/things/i1")
+	// itemHandler — registered at /items/{path1:.*}.
+	resp, err := http.Get("http://" + proxyServer.Address + "/items/i1")
 	require.NoError(t, err)
 	resp.Body.Close()
-	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode,
+		"itemHandler must be gated by Audit")
 
-	// Base path.
-	resp, err = http.Get("http://" + proxyServer.Address + "/devices/d1/things")
+	// listHandler — registered at /items (basePath). This request
+	// matches the registered route directly (not the data wildcard),
+	// so the 401 must come from the listHandler's AuditHandler wrap.
+	resp, err = http.Get("http://" + proxyServer.Address + "/items")
 	require.NoError(t, err)
 	resp.Body.Close()
-	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode,
+		"listHandler must be gated by Audit")
 
 	require.False(t, upstreamHit.Load(), "upstream must not be contacted when Audit denies")
+}
+
+// TestProxyAuditGatesWebSocketUpgrade asserts that the AuditHandler
+// wrap runs BEFORE the proxy closure's websocket.IsWebSocketUpgrade
+// branch. A WebSocket dial against a deny-everything Audit must
+// receive a clean HTTP 401 before any upgrade is attempted, so the
+// client never enters a half-upgraded state. The structural
+// guarantee comes from AuditHandler being the outer wrapper; this
+// test locks that ordering against future refactors that might move
+// the gate inside the inner closure.
+func TestProxyAuditGatesWebSocketUpgrade(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+
+	var upstreamHit atomic.Bool
+	upstream := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		upstreamHit.Store(true)
+	}))
+	defer upstream.Close()
+	upstreamHost := strings.TrimPrefix(upstream.URL, "http://")
+
+	proxyServer := &ooo.Server{}
+	proxyServer.Silence = true
+	proxyServer.Audit = func(r *http.Request) bool { return false }
+
+	err := proxy.Route(proxyServer, "settings/{deviceID}", proxy.Config{
+		Resolve: func(_ string) (string, string, error) {
+			return upstreamHost, "", nil
+		},
+	})
+	require.NoError(t, err)
+	proxyServer.Start("localhost:0")
+	defer proxyServer.Close(os.Interrupt)
+
+	u := url.URL{Scheme: "ws", Host: proxyServer.Address, Path: "/settings/device1"}
+	c, resp, err := websocket.DefaultDialer.Dial(u.String(), nil)
+	require.Error(t, err, "deny-everything Audit must reject the upgrade")
+	if c != nil {
+		c.Close()
+	}
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode,
+		"client must see HTTP 401, not a half-upgraded WS connection")
+	require.False(t, upstreamHit.Load())
 }
 
 // TestProxyAuditGatesRouteWithVars asserts the same for RouteWithVars.


### PR DESCRIPTION
Closes #100

## Summary
- New `Server.AuditHandler(http.HandlerFunc) http.HandlerFunc` middleware that runs `Server.Audit` before forwarding to the wrapped handler; returns 401 + `ErrNotAuthorized` on denial.
- Applied at every custom-route registration site: `Server.Endpoint`, `proxy.Route`, `proxy.RouteList` (base + item handler), `proxy.RouteWithVars`. `RouteNodeFilter` / `RouteNodeListFilter` inherit the gate through their delegation.
- AuditHandler runs BEFORE the proxy closure's `enforceCapability` check and BEFORE the WebSocket-upgrade branch, so denied requests never reach upstream and never half-upgrade a WS connection.

## Test plan
- [x] `TestAuditGatesEndpoint` — deny-everything Audit, custom Endpoint, asserts 401 + handler did not run.
- [x] `TestProxyAuditGatesRoute` / `RouteList` / `RouteWithVars` — three new tests cover each proxy registrar with a deny-everything Audit; assert 401 + upstream not contacted.
- [x] Existing `TestAudit` (REST handlers self-gate via `Audit(r)`) still passes; no regression.
- [x] `go test ./... -race` clean across the workspace.

## Notes
Pre-flight self-review caught two issues, both fixed before this PR opened:
- The `AuditHandler` doc claimed nil-Audit allow-through "matches pre-Start behavior of the built-in handlers", which is wrong (rest.go panics on nil Audit). Comment now describes it accurately as a defensive guard for direct-Router test paths.
- New tests used bare `bool` for `upstreamHit`. Switched to `atomic.Bool` so the failing pre-fix run under `-race` surfaces the audit assertion cleanly without a concurrent-write race muddying the signal.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)