### PR TITLE
fix(proxy): keep per-path upstream unique across subscriber teardowns

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/benitogf/coat"
@@ -25,6 +26,48 @@ var (
 	ErrLocalPathEmpty   = errors.New("proxy: LocalPath is required")
 	ErrResolveFailed    = errors.New("proxy: failed to resolve target")
 )
+
+// teardownPauseHook is a test seam invoked inside the WS handler's
+// teardown between stopRemoteSubscription and removeState. afterTeardownHook
+// fires immediately after removeState returns. Production callers leave
+// both nil so the calls are zero-cost branches. Tests set them to
+// barrier-based callbacks so the lifecycle race window between "state
+// is being torn down" and "new subscriber arrives for the same path"
+// can be exercised — and verified to have settled — deterministically.
+//
+// Wrapped in atomic.Pointer so the WS handler can read them racelessly
+// while a test goroutine concurrently installs or clears via the
+// SetTeardown*ForTest setters.
+var (
+	teardownPauseHook atomic.Pointer[func()]
+	afterTeardownHook atomic.Pointer[func()]
+)
+
+// SetTeardownPauseHookForTest installs a callback invoked inside the
+// WS handler's teardown between stopRemoteSubscription and removeState.
+// Tests only — production callers leave the hook nil. Pass nil to
+// clear. Single-shot: tests must not assume the hook fires more than
+// once per install. Not safe for concurrent test execution; tests
+// using this hook must not run with t.Parallel.
+func SetTeardownPauseHookForTest(fn func()) {
+	if fn == nil {
+		teardownPauseHook.Store(nil)
+		return
+	}
+	teardownPauseHook.Store(&fn)
+}
+
+// SetAfterTeardownHookForTest installs a callback invoked inside the
+// WS handler's teardown after removeState returns. Tests use this to
+// know when a subscriber teardown has fully settled before introducing
+// the next subscriber. Same constraints as SetTeardownPauseHookForTest.
+func SetAfterTeardownHookForTest(fn func()) {
+	if fn == nil {
+		afterTeardownHook.Store(nil)
+		return
+	}
+	afterTeardownHook.Store(&fn)
+}
 
 // Resolver maps local path to remote server address and path.
 // localPath example: "settings/device123"
@@ -129,8 +172,14 @@ type wsMessage struct {
 }
 
 type proxyState struct {
-	mu              sync.Mutex
-	wg              sync.WaitGroup // tracks remote subscription goroutine
+	mu sync.Mutex
+	wg sync.WaitGroup // tracks remote subscription goroutine
+	// dying flips to true under mu as soon as the last subscriber
+	// leaves, so a concurrent addSubscriber on the same state pointer
+	// can detect the in-progress teardown and ask the caller to
+	// refetch from the manager. getOrCreateState also consults it so
+	// the registry hands out a fresh state instead of the dying one.
+	dying           bool
 	address         string
 	remotePath      string
 	localSubs       map[*websocket.Conn]chan wsMessage
@@ -157,6 +206,24 @@ func (pm *proxyManager) getOrCreateState(address, remotePath string, cfg *client
 	defer pm.mu.Unlock()
 
 	state, exists := pm.states[key]
+	if exists {
+		state.mu.Lock()
+		if state.dying {
+			// A teardown for this state is mid-flight and has not yet
+			// reached removeState. Replace it in the registry with a
+			// fresh state so this new subscriber starts its own
+			// remote subscription instead of attaching to the
+			// half-torn-down one. The dying state's removeState will
+			// see the pointer mismatch and skip its delete.
+			state.mu.Unlock()
+			exists = false
+		} else {
+			// Reusable state: update protocol for the new client
+			// (auth credentials may differ from the previous client).
+			state.clientProtocol = clientProtocol
+			state.mu.Unlock()
+		}
+	}
 	if !exists {
 		state = &proxyState{
 			address:        address,
@@ -168,20 +235,22 @@ func (pm *proxyManager) getOrCreateState(address, remotePath string, cfg *client
 			clientProtocol: clientProtocol,
 		}
 		pm.states[key] = state
-	} else {
-		// Update protocol for reused state — a new client may have
-		// different auth credentials than the previous one.
-		state.mu.Lock()
-		state.clientProtocol = clientProtocol
-		state.mu.Unlock()
 	}
 	return state
 }
 
-func (pm *proxyManager) removeState(address, remotePath string) {
+// removeState deletes the state for (address, remotePath) from the
+// registry, but only if the registered pointer still matches the one
+// the caller observed. After a teardown stops the remote subscription,
+// a concurrent getOrCreateState may have already replaced the dying
+// state with a fresh one; compare-and-delete prevents the teardown
+// from evicting that fresh state.
+func (pm *proxyManager) removeState(address, remotePath string, expected *proxyState) {
 	key := address + "/" + remotePath
 	pm.mu.Lock()
-	delete(pm.states, key)
+	if pm.states[key] == expected {
+		delete(pm.states, key)
+	}
 	pm.mu.Unlock()
 }
 
@@ -205,9 +274,17 @@ func (ps *proxyState) logPrefix() string {
 	return "proxy[" + ps.address + "/" + ps.remotePath + "]"
 }
 
+// addSubscriber registers conn with the state and returns the
+// per-subscriber outbox. Returns nil if the state is being torn down
+// — the caller must refetch a fresh state from the manager and try
+// again.
 func (ps *proxyState) addSubscriber(conn *websocket.Conn) chan wsMessage {
 	msgChan := make(chan wsMessage, 10)
 	ps.mu.Lock()
+	if ps.dying {
+		ps.mu.Unlock()
+		return nil
+	}
 	wasEmpty := len(ps.localSubs) == 0
 	remoteAlreadyConnected := ps.remoteConnected
 	ps.localSubs[conn] = msgChan
@@ -324,8 +401,16 @@ func (ps *proxyState) removeSubscriber(conn *websocket.Conn) bool {
 		delete(ps.localSubs, conn)
 	}
 
-	// Return true if no more subscribers
-	return len(ps.localSubs) == 0
+	// Flip dying as soon as the state empties so a concurrent
+	// addSubscriber on the same pointer (one that observed the state
+	// before getOrCreateState had a chance to replace it) can detect
+	// the in-progress teardown. Pairs with the dying check in
+	// addSubscriber and the registry replacement in getOrCreateState.
+	if len(ps.localSubs) == 0 {
+		ps.dying = true
+		return true
+	}
+	return false
 }
 
 func (ps *proxyState) broadcastRaw(msgType int, data []byte) {
@@ -660,15 +745,35 @@ func handleWebSocketProxy(w http.ResponseWriter, r *http.Request, pm *proxyManag
 		return
 	}
 
-	state := pm.getOrCreateState(address, remotePath, subCfg, isList, clientProtocol)
-	msgChan := state.addSubscriber(localConn)
+	// Retry loop: if getOrCreateState returned a state that flipped to
+	// dying between the registry lookup and the addSubscriber call,
+	// fetch again. The dying state will have been replaced by then
+	// (either by our retry triggering replacement, or by the teardown
+	// completing). The retry is bounded — each iteration either
+	// attaches or hands back to the manager for a fresh state — so
+	// it cannot livelock.
+	var state *proxyState
+	var msgChan chan wsMessage
+	for {
+		state = pm.getOrCreateState(address, remotePath, subCfg, isList, clientProtocol)
+		msgChan = state.addSubscriber(localConn)
+		if msgChan != nil {
+			break
+		}
+	}
 
 	// Forward messages to local subscriber
 	go func() {
 		defer func() {
 			if state.removeSubscriber(localConn) {
 				state.stopRemoteSubscription()
-				pm.removeState(address, remotePath)
+				if hook := teardownPauseHook.Load(); hook != nil {
+					(*hook)()
+				}
+				pm.removeState(address, remotePath, state)
+				if hook := afterTeardownHook.Load(); hook != nil {
+					(*hook)()
+				}
 			}
 			localConn.Close()
 		}()

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -2,6 +2,7 @@ package proxy_test
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -1758,6 +1759,162 @@ func TestProxyAuditGatesRouteWithVars(t *testing.T) {
 	defer resp.Body.Close()
 	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 	require.False(t, upstreamHit.Load())
+}
+
+// TestProxySubscriberTeardownRaceDoesNotOrphanNewSubscriber
+// reproduces the race the audit flagged: between the last subscriber
+// emptying a proxyState and removeState deleting it from the
+// registry, a new subscriber for the same path could observe the
+// dying state, attach to it, and lose its upstream subscription.
+// The fix flips a dying flag inside removeSubscriber, makes
+// getOrCreateState replace dying states, and lets addSubscriber
+// refuse a dying state so the WS handler retries. removeState then
+// compare-and-deletes so it cannot evict the fresh state that took
+// the dying one's place.
+//
+// The test uses the package-level teardownPauseHook to deterministic-
+// ally hold A's teardown in the race window while B opens. Pre-fix
+// B's state has no remote subscription (A's was stopped while B's
+// was building on the same pointer) so the subsequent remote Set
+// never reaches B. Post-fix B gets a fresh state with its own
+// remote subscription and receives the update.
+func TestProxySubscriberTeardownRaceDoesNotOrphanNewSubscriber(t *testing.T) {
+	// Don't run in parallel — teardownPauseHook is package-level and
+	// parallel tests would clobber each other.
+
+	resume := make(chan struct{})
+	hookFired := make(chan struct{}, 1)
+	teardownDone := make(chan struct{}, 1)
+	proxy.SetTeardownPauseHookForTest(func() {
+		select {
+		case hookFired <- struct{}{}:
+		default:
+		}
+		<-resume
+	})
+	defer proxy.SetTeardownPauseHookForTest(nil)
+	proxy.SetAfterTeardownHookForTest(func() {
+		select {
+		case teardownDone <- struct{}{}:
+		default:
+		}
+	})
+	defer proxy.SetAfterTeardownHookForTest(nil)
+
+	remote := &ooo.Server{}
+	remote.Silence = true
+	remote.OpenFilter("settings")
+	remote.Start("localhost:0")
+	defer remote.Close(os.Interrupt)
+	_, err := remote.Storage.Set("settings", []byte(`{"name":"seed","value":0}`))
+	require.NoError(t, err)
+
+	proxyServer := &ooo.Server{}
+	proxyServer.Silence = true
+	err = proxy.Route(proxyServer, "settings/{deviceID}", proxy.Config{
+		Resolve: func(_ string) (string, string, error) {
+			return remote.Address, "settings", nil
+		},
+	})
+	require.NoError(t, err)
+	proxyServer.Start("localhost:0")
+	defer proxyServer.Close(os.Interrupt)
+
+	u := url.URL{Scheme: "ws", Host: proxyServer.Address, Path: "/settings/device1"}
+
+	// Subscriber A: connects, reads initial snapshot, then forces the
+	// TCP socket closed so the proxy's forwarder fails on its next
+	// WriteMessage and triggers the teardown defer. cA.Close() sends a
+	// graceful WS close which gorilla may absorb without failing the
+	// next write; UnderlyingConn().Close() is the deterministic
+	// hammer.
+	cA, _, err := websocket.DefaultDialer.Dial(u.String(), nil)
+	require.NoError(t, err)
+	_, _, err = cA.ReadMessage()
+	require.NoError(t, err)
+	require.NoError(t, cA.UnderlyingConn().Close())
+
+	// Fan a few Sets at the upstream — each one broadcasts through
+	// the proxy and pushes a wsMessage onto A's msgChan, eventually
+	// driving A's forwarder into a failed WriteMessage that fires
+	// the teardown defer.
+	fired := false
+	for i := range 20 {
+		_, err = remote.Storage.Set("settings", []byte(fmt.Sprintf(`{"name":"wake-A","value":%d}`, i)))
+		require.NoError(t, err)
+		select {
+		case <-hookFired:
+			fired = true
+		case <-time.After(100 * time.Millisecond):
+		}
+		if fired {
+			break
+		}
+	}
+	if !fired {
+		close(resume)
+		t.Fatal("teardown hook did not fire after fanning 20 Sets")
+	}
+
+	// Subscriber B: opens while A's state is still in the registry.
+	// Pre-fix B attaches to the dying state — its addSubscriber sees
+	// wasEmpty (A removed) and kicks off a fresh remote sub on the
+	// SAME state pointer that A's teardown is about to evict from
+	// the registry. Result: B's state survives but is orphaned.
+	cB, _, err := websocket.DefaultDialer.Dial(u.String(), nil)
+	require.NoError(t, err)
+	defer cB.Close()
+	_, _, err = cB.ReadMessage() // initial snapshot
+	require.NoError(t, err)
+
+	// Release A's teardown so removeState runs.
+	close(resume)
+
+	// Wait for A's afterTeardownHook to fire, signalling removeState
+	// has returned. Pre-fix it evicts state1 (the one B is attached
+	// to) from the registry; post-fix the compare-and-delete sees a
+	// fresh state in the slot and skips the eviction. Either way,
+	// C's subsequent dial must happen after A's removeState has
+	// fully settled or the test races with the teardown.
+	select {
+	case <-teardownDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("A's teardown did not settle (afterTeardownHook never fired)")
+	}
+
+	// Subscriber C: opens for the SAME path. Pre-fix B's state was
+	// evicted by A's removeState, so C creates a brand-new state3
+	// with its own upstream connection — and the proxy now holds
+	// TWO upstream subs to remote for the same path. Post-fix B's
+	// state was preserved (either via dying-flag replacement at
+	// add time or via compare-and-delete in removeState), and C
+	// reuses it — proxy holds ONE upstream sub.
+	cC, _, err := websocket.DefaultDialer.Dial(u.String(), nil)
+	require.NoError(t, err)
+	defer cC.Close()
+	_, _, err = cC.ReadMessage() // initial snapshot
+	require.NoError(t, err)
+
+	// The remote sees the proxy's upstream subscriptions. With the
+	// audit-flagged race, two parallel states each hold their own
+	// upstream — connection count = 2. With the fix, B and C share
+	// one state and one upstream — connection count = 1.
+	deadline := time.Now().Add(1 * time.Second)
+	var connCount int
+	for time.Now().Before(deadline) {
+		connCount = 0
+		for _, pool := range remote.Stream.GetState() {
+			connCount += pool.Connections
+		}
+		if connCount == 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	require.Equal(t, 1, connCount,
+		"proxy must share one upstream subscription across B and C; "+
+			"pre-fix the teardown race leaves B on a stranded state with its own upstream "+
+			"while C creates a fresh state with another, doubling the upstream conn count")
 }
 
 func TestProxyServerCloseTearsDownSubscriptions(t *testing.T) {


### PR DESCRIPTION
Closes #102

## Summary
- `proxyState.dying` flips under `ps.mu` the moment `removeSubscriber` drains the last conn.
- `getOrCreateState` consults `dying` under both locks and replaces the registry entry with a fresh state when the existing one is being torn down.
- `addSubscriber` refuses dying states (returns nil); the WS handler retries via `getOrCreateState` until it gets a fresh state.
- `removeState` becomes compare-and-delete so a teardown whose slot was already replaced cannot evict the replacement.

## Test plan
- [x] `TestProxySubscriberTeardownRaceDoesNotOrphanNewSubscriber` uses two `atomic.Pointer`-guarded hooks (`teardownPauseHook` + `afterTeardownHook`) to deterministically hold A's teardown in the race window, open B, settle A's `removeState`, then open C — asserts `remote.Stream.GetState` reports exactly 1 upstream connection. Pre-fix the assertion fires with `connCount=2`; verified by surgically reverting the dying-flag / cmp-and-delete logic while keeping the hook infrastructure.
- [x] `go test ./... -race` clean across the workspace.

## Notes
- Pre-flight self-review by a fresh sub-agent — zero blockers. Two in-change non-blockers caught and fixed: replaced the test's `time.Sleep(50ms)` with the `afterTeardownHook` deterministic signal so the failing-premise reproduces reliably on slow CI; documented `SetTeardownPauseHookForTest` as single-shot.
- Three deferred non-blockers tracked separately by the reviewer: `CloseAll` not flipping `dying` on its torn-down states (pre-existing pattern, doesn't regress with this diff), `removeState` silent no-op on pointer mismatch (debug-log nice-to-have), retry-loop unbounded (pragmatically bounded by concurrent-subscriber count).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)