### PR TITLE
fix(server): synchronize endpoint + proxy registries with the UI

### DIFF
--- a/audit_test.go
+++ b/audit_test.go
@@ -2,18 +2,102 @@ package ooo_test
 
 import (
 	"bytes"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
 	"runtime"
+	"sync"
 	"testing"
 
 	"github.com/benitogf/go-json"
 	"github.com/benitogf/ooo"
+	"github.com/benitogf/ooo/ui"
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/require"
 )
+
+// TestRegisterProxyConcurrentWithRead asserts that RegisterProxy
+// can run concurrently with the explorer UI's GetProxies callback
+// (and the equivalent Endpoint-slice read via GetEndpoints). Pre-fix
+// the endpoints + proxies slices were appended without any lock and
+// read without any lock, so under -race a parallel registration + UI
+// fetch fired a data race. Sibling registrars RegisterProxyCleanup /
+// RegisterPreClose already used mutexes for the same pattern; this
+// test pins that the endpoint + proxy registries do too.
+//
+// The test exercises RegisterProxy specifically (no mux.Router
+// mutation) so the assertion isolates the registry-slice race the
+// audit item flagged. Concurrent Endpoint() registrations have a
+// separate race in gorilla/mux's Router.HandleFunc vs Router.Match
+// — tracked as its own audit-list item.
+func TestRegisterProxyConcurrentWithRead(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+	server := ooo.Server{}
+	server.Silence = true
+	server.Start("localhost:0")
+	defer server.Close(os.Interrupt)
+
+	// Register one Endpoint up front so the UI read path also iterates
+	// over a non-empty endpoints slice during the concurrent section.
+	server.Endpoint(ooo.EndpointConfig{
+		Path: "/seed",
+		Methods: ooo.Methods{
+			http.MethodGet: {Response: nil},
+		},
+		Handler: func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		},
+	})
+
+	const writers = 8
+	const readers = 8
+	const iterations = 25
+
+	barrier := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(writers + readers)
+
+	for w := range writers {
+		go func() {
+			defer wg.Done()
+			<-barrier
+			for i := range iterations {
+				server.RegisterProxy(ui.ProxyInfo{
+					LocalPath: fmt.Sprintf("dyn-proxy-%d-%d", w, i),
+				})
+			}
+		}()
+	}
+
+	// The explorer UI's read paths are GET /?api=endpoints and
+	// /?api=proxies (see ui/ui.go: `switch r.URL.Query().Get("api")`).
+	// A bare GET / serves the static index and never enters
+	// getEndpoints/getProxies, so the readers must explicitly request
+	// each API to exercise both halves of the fix.
+	for r := range readers {
+		api := "endpoints"
+		if r%2 == 1 {
+			api = "proxies"
+		}
+		go func(api string) {
+			defer wg.Done()
+			<-barrier
+			for range iterations {
+				req := httptest.NewRequest(http.MethodGet, "/?api="+api, nil)
+				rec := httptest.NewRecorder()
+				server.Router.ServeHTTP(rec, req)
+				_ = rec.Result()
+			}
+		}(api)
+	}
+
+	close(barrier)
+	wg.Wait()
+}
 
 // TestAuditGatesEndpoint asserts that a custom Endpoint registered
 // via Server.Endpoint honors Server.Audit. Pre-fix the endpoint

--- a/endpoint.go
+++ b/endpoint.go
@@ -223,18 +223,24 @@ func (server *Server) Endpoint(cfg EndpointConfig) {
 	server.Router.HandleFunc(cfg.Path, server.AuditHandler(cfg.Handler)).Methods(methods...)
 	server.RegisterOracleRoute(cfg.Path, methods)
 
-	// Track for UI
+	// Track for UI. The append needs to serialize with getEndpoints
+	// (the explorer UI hot path), so take the registry write lock.
+	server.registryMu.Lock()
 	server.endpoints = append(server.endpoints, ui.EndpointInfo{
 		Path:        cfg.Path,
 		Methods:     methodInfos,
 		Description: cfg.Description,
 		Vars:        vars,
 	})
+	server.registryMu.Unlock()
 }
 
-// RegisterProxy registers a proxy route for UI visibility
+// RegisterProxy registers a proxy route for UI visibility. The append
+// serializes with getProxies via the shared registry write lock.
 func (server *Server) RegisterProxy(info ui.ProxyInfo) {
+	server.registryMu.Lock()
 	server.proxies = append(server.proxies, info)
+	server.registryMu.Unlock()
 }
 
 // RegisterProxyCleanup registers a cleanup function to be called when the server closes.
@@ -255,20 +261,42 @@ func (server *Server) RegisterPreClose(cleanup func()) {
 	server.preCloseCleanupsMu.Unlock()
 }
 
-// getEndpoints returns registered endpoints for UI
+// getEndpoints returns a snapshot of the registered endpoints. Takes
+// the registry read lock and returns a copy of the slice header so
+// the caller can iterate without contending with concurrent Endpoint
+// registrations.
+//
+// The copy is shallow: an EndpointInfo's Methods slice and Vars map
+// share backing memory with the registered entry. This is safe
+// because already-registered EndpointInfo values are treated as
+// immutable — Endpoint() only ever appends, nothing post-registration
+// mutates an existing entry. Callers must preserve that invariant
+// and not mutate the returned entries.
 func (server *Server) getEndpoints() []ui.EndpointInfo {
-	if server.endpoints == nil {
+	server.registryMu.RLock()
+	defer server.registryMu.RUnlock()
+	if len(server.endpoints) == 0 {
 		return []ui.EndpointInfo{}
 	}
-	return server.endpoints
+	snapshot := make([]ui.EndpointInfo, len(server.endpoints))
+	copy(snapshot, server.endpoints)
+	return snapshot
 }
 
-// getProxies returns registered proxies for UI
+// getProxies returns a snapshot of the registered proxies. Takes the
+// registry read lock and returns a copy of the slice header so the
+// caller can iterate without contending with concurrent RegisterProxy
+// calls. ProxyInfo carries only scalars; the shallow snapshot is
+// fully independent of the registry.
 func (server *Server) getProxies() []ui.ProxyInfo {
-	if server.proxies == nil {
+	server.registryMu.RLock()
+	defer server.registryMu.RUnlock()
+	if len(server.proxies) == 0 {
 		return []ui.ProxyInfo{}
 	}
-	return server.proxies
+	snapshot := make([]ui.ProxyInfo, len(server.proxies))
+	copy(snapshot, server.proxies)
+	return snapshot
 }
 
 // getOrphanKeys returns keys that don't match any filter

--- a/ooo.go
+++ b/ooo.go
@@ -116,23 +116,28 @@ type audit func(r *http.Request) bool
 //
 // BeforeRead: callback function triggered before read operations
 type Server struct {
-	wg                 sync.WaitGroup
-	watchWg            sync.WaitGroup
-	listenWg           sync.WaitGroup
-	handlerWg          sync.WaitGroup
-	clockWg            sync.WaitGroup
-	server             *http.Server
-	Name               string
-	Router             *mux.Router
-	Stream             stream.Stream
-	filters            filters.Filters
-	limitFilters       map[string]*limitFilterReg // tracks limit filter registrations
-	endpoints          []ui.EndpointInfo          // registered custom endpoints
-	proxies            []ui.ProxyInfo             // registered proxy routes
-	routeOracle        *mux.Router                // mirrors Endpoint/Proxy paths so the data wildcard can defer to them
-	routeOracleMu      sync.RWMutex               // protects routeOracle; readers (routeOracleSkip) take RLock on the data-wildcard hot path, registrations take Lock
-	proxyCleanups      []func()                   // cleanup functions for proxy subscriptions
-	proxyCleanupMu     sync.Mutex                 // protects proxyCleanups
+	wg           sync.WaitGroup
+	watchWg      sync.WaitGroup
+	listenWg     sync.WaitGroup
+	handlerWg    sync.WaitGroup
+	clockWg      sync.WaitGroup
+	server       *http.Server
+	Name         string
+	Router       *mux.Router
+	Stream       stream.Stream
+	filters      filters.Filters
+	limitFilters map[string]*limitFilterReg // tracks limit filter registrations
+	endpoints    []ui.EndpointInfo          // registered custom endpoints
+	proxies      []ui.ProxyInfo             // registered proxy routes
+	// registryMu protects endpoints + proxies. Sibling cleanup-slice
+	// registrars (RegisterProxyCleanup, RegisterPreClose) already
+	// lock; these used to mutate without one and raced against
+	// getEndpoints/getProxies from the explorer UI hot path.
+	registryMu         sync.RWMutex
+	routeOracle        *mux.Router  // mirrors Endpoint/Proxy paths so the data wildcard can defer to them
+	routeOracleMu      sync.RWMutex // protects routeOracle; readers (routeOracleSkip) take RLock on the data-wildcard hot path, registrations take Lock
+	proxyCleanups      []func()     // cleanup functions for proxy subscriptions
+	proxyCleanupMu     sync.Mutex   // protects proxyCleanups
 	NoBroadcastKeys    []string
 	Audit              audit
 	Workers            int


### PR DESCRIPTION
Closes #104

## Summary
- Add `Server.registryMu sync.RWMutex` protecting both `endpoints` and `proxies` slices.
- `Server.Endpoint` and `Server.RegisterProxy` take the write `Lock` around their append.
- `getEndpoints` and `getProxies` take `RLock` and return a snapshot so the UI handler can iterate without holding the lock.

## Test plan
- [x] `TestRegisterProxyConcurrentWithRead` — 8 writers × 25 `RegisterProxy` + 8 readers × 25 `GET /?api={endpoints,proxies}` behind a barrier. Pre-fix fires the race detector; post-fix race-clean. Verified by surgically reverting the read-side snapshot alone: the test fails under `-race`, confirming both halves of the fix are load-bearing.
- [x] `go test ./... -race` clean across the workspace.

## Notes
- Self-review caught a blocker: my original test used `GET /` which serves the static `index.html`, not the API. Replaced with `GET /?api=endpoints` / `GET /?api=proxies` so the assertion actually exercises `getEndpoints`/`getProxies`.
- Also documented the shallow-snapshot contract on `getEndpoints` (Methods slice and Vars map share backing memory with the registered entry; safe because registered entries are immutable).
- A separate, broader race in `gorilla/mux.Router.HandleFunc` vs `Router.Match` surfaced when my early test included concurrent `Endpoint` calls — the main `server.Router` has no equivalent locking even though the route-oracle `Router` was already fixed in PR #99. Added as a new audit-list entry; out of scope here per "one item per PR".

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)