### PR TITLE
fix(server): synchronize Server.Router with concurrent dispatch

### DIFF
--- a/audit_test.go
+++ b/audit_test.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/benitogf/go-json"
 	"github.com/benitogf/ooo"
@@ -17,6 +18,73 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/require"
 )
+
+// TestServerRouterConcurrentEndpointAndServeHTTP asserts that
+// Server.Endpoint can run concurrently with request dispatch through
+// the server's main Router. Pre-fix gorilla/mux.Router has internal
+// state (its `routes` slice and per-route regex caches) that mutates
+// inside HandleFunc and is read inside Match; with no external
+// synchronization, parallel registration + ServeHTTP fires a data
+// race. The route-oracle Router was fixed in PR #99 to take
+// sync.RWMutex; the main server.Router needs the same discipline.
+func TestServerRouterConcurrentEndpointAndServeHTTP(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+	server := ooo.Server{}
+	server.Silence = true
+	server.Start("localhost:0")
+	defer server.Close(os.Interrupt)
+
+	const writers = 6
+	const readers = 6
+	const iterations = 20
+
+	barrier := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(writers + readers)
+
+	for w := range writers {
+		go func() {
+			defer wg.Done()
+			<-barrier
+			for i := range iterations {
+				path := fmt.Sprintf("/dyn-route-%d-%d", w, i)
+				server.Endpoint(ooo.EndpointConfig{
+					Path: path,
+					Methods: ooo.Methods{
+						http.MethodGet: {Response: nil},
+					},
+					Handler: func(rw http.ResponseWriter, _ *http.Request) {
+						rw.WriteHeader(http.StatusOK)
+					},
+				})
+			}
+		}()
+	}
+
+	addr := "http://" + server.Address
+	client := &http.Client{Timeout: 5 * time.Second}
+	for range readers {
+		go func() {
+			defer wg.Done()
+			<-barrier
+			for range iterations {
+				// Use the real HTTP server so requests go through the
+				// production handler chain — syncRouter wraps the mux
+				// router only at server.server.Handler. Direct calls
+				// to server.Router.ServeHTTP would bypass the wrapper.
+				resp, err := client.Get(addr + "/some-key")
+				if err == nil {
+					resp.Body.Close()
+				}
+			}
+		}()
+	}
+
+	close(barrier)
+	wg.Wait()
+}
 
 // TestRegisterProxyConcurrentWithRead asserts that RegisterProxy
 // can run concurrently with the explorer UI's GetProxies callback

--- a/endpoint.go
+++ b/endpoint.go
@@ -220,7 +220,11 @@ func (server *Server) Endpoint(cfg EndpointConfig) {
 	// data wildcard defers to this Endpoint regardless of registration
 	// order. Wrap the handler in AuditHandler so Server.Audit gates the
 	// custom path the same way it gates the built-in REST handlers.
-	server.Router.HandleFunc(cfg.Path, server.AuditHandler(cfg.Handler)).Methods(methods...)
+	// RouterMutate serializes this with the syncRouter wrapper's Match
+	// so concurrent request dispatch is race-free.
+	server.RouterMutate(func() {
+		server.Router.HandleFunc(cfg.Path, server.AuditHandler(cfg.Handler)).Methods(methods...)
+	})
 	server.RegisterOracleRoute(cfg.Path, methods)
 
 	// Track for UI. The append needs to serialize with getEndpoints

--- a/ooo.go
+++ b/ooo.go
@@ -29,6 +29,68 @@ import (
 
 const deadlineMsg = "ooo: server deadline reached"
 
+// syncRouter wraps Server.Router so the gorilla/mux internal routes
+// slice (mutated by HandleFunc/Handle, read by Match) cannot race
+// with concurrent request dispatch. ServeHTTP takes the routerMu
+// read lock around Match only — the dispatched handler runs WITHOUT
+// the lock so long-running handlers (WebSocket forwarders, hijacked
+// connections) do not block subsequent registrations.
+//
+// mux.SetURLVars propagates the matched vars into the request
+// context so handlers continue to read them via mux.Vars(r). This
+// covers every consumer in the tree (REST, WS, proxy); none of them
+// use mux.CurrentRoute, which gorilla/mux does not expose a public
+// setter for.
+//
+// Known deviations from mux.Router.ServeHTTP:
+//   - No path cleaning + 301 redirect for non-canonical paths
+//     (mux does this when SkipClean(true) has NOT been set). The
+//     codebase does not depend on it. Add a port of mux's cleanPath
+//     here if a future consumer needs it.
+//   - mux Router.Use() middlewares are not fanned out. The codebase
+//     does not register any. If middleware support is added later,
+//     this wrapper must chain them onto the matched handler.
+type syncRouter struct {
+	router *mux.Router
+	mu     *sync.RWMutex
+}
+
+func (s *syncRouter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.mu.RLock()
+	var match mux.RouteMatch
+	matched := s.router.Match(r, &match)
+	s.mu.RUnlock()
+
+	var handler http.Handler
+	if matched {
+		handler = match.Handler
+		// Match mux's unconditional vars propagation — handlers
+		// distinguish "no vars" from "vars never set" by reading
+		// the context, so don't gate on len.
+		r = mux.SetURLVars(r, match.Vars)
+	}
+	if handler == nil && match.MatchErr == mux.ErrMethodMismatch {
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		return
+	}
+	if handler == nil {
+		http.NotFound(w, r)
+		return
+	}
+	handler.ServeHTTP(w, r)
+}
+
+// RouterMutate runs fn while holding the routerMu write lock so
+// Server.Router mutations (HandleFunc, Handle, MatcherFunc chaining)
+// serialize with the syncRouter wrapper's Match. Used by Endpoint,
+// setupRoutes, and the proxy package's Route/RouteList/RouteWithVars
+// registrars.
+func (server *Server) RouterMutate(fn func()) {
+	server.routerMu.Lock()
+	defer server.routerMu.Unlock()
+	fn()
+}
+
 // Server.active state machine. The intermediate serverStarting value
 // is what makes Active() return false during the listen-bind window
 // while still keeping concurrent StartWithError callers off the
@@ -133,7 +195,16 @@ type Server struct {
 	// registrars (RegisterProxyCleanup, RegisterPreClose) already
 	// lock; these used to mutate without one and raced against
 	// getEndpoints/getProxies from the explorer UI hot path.
-	registryMu         sync.RWMutex
+	registryMu sync.RWMutex
+	// routerMu protects Server.Router. gorilla/mux.Router mutates an
+	// internal routes slice on HandleFunc/Handle and reads it on
+	// Match; without serialization a registration concurrent with
+	// request dispatch races on those internals. Mutators take Lock
+	// via RouterMutate; the syncRouter wrapper installed in
+	// waitListen takes RLock around Match, then dispatches the
+	// matched handler without the lock so long-running handlers do
+	// not block subsequent registrations.
+	routerMu           sync.RWMutex
 	routeOracle        *mux.Router  // mirrors Endpoint/Proxy paths so the data wildcard can defer to them
 	routeOracleMu      sync.RWMutex // protects routeOracle; readers (routeOracleSkip) take RLock on the data-wildcard hot path, registrations take Lock
 	proxyCleanups      []func()     // cleanup functions for proxy subscriptions
@@ -349,7 +420,11 @@ func (server *Server) waitListen() {
 		server.wg.Done()
 		return
 	}
-	var handler http.Handler = server.Router
+	// Wrap server.Router so concurrent Endpoint/Proxy registrations
+	// cannot race with the request-dispatch Match. The wrapper takes
+	// the routerMu read lock around Match and dispatches the matched
+	// handler without holding the lock.
+	var handler http.Handler = &syncRouter{router: server.Router, mu: &server.routerMu}
 	if !server.NoCompress {
 		handler = handlers.CompressHandler(handler)
 	}
@@ -677,7 +752,15 @@ func (server *Server) defaults() {
 }
 
 // setupRoutes configures the HTTP routes for the server.
+//
+// Runs from defaults() inside StartWithError, which is CAS-gated and
+// runs before any traffic reaches the wrapper, so this code is not
+// racing with ServeHTTP. The routerMu.Lock is defensive — it keeps
+// the "mutators take Lock" invariant uniform across every router
+// registration site, including the boot-time ones.
 func (server *Server) setupRoutes() {
+	server.routerMu.Lock()
+	defer server.routerMu.Unlock()
 	// https://ieftimov.com/post/make-resilient-golang-net-http-servers-using-timeouts-deadlines-context-cancellation/
 	explorerHandler := &ui.Handler{
 		GetKeys:        server.Storage.Keys,

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -608,8 +608,11 @@ func Route(server *ooo.Server, localPath string, cfg Config) error {
 	// wildcard defers to this proxy regardless of registration order.
 	// AuditHandler runs Server.Audit before the proxy handler so
 	// proxied paths participate in the same auth gate as built-in
-	// REST handlers.
-	server.Router.HandleFunc("/"+muxPattern, server.AuditHandler(handler))
+	// REST handlers. RouterMutate serializes this with the
+	// syncRouter wrapper's Match.
+	server.RouterMutate(func() {
+		server.Router.HandleFunc("/"+muxPattern, server.AuditHandler(handler))
+	})
 	server.RegisterOracleRoute("/"+muxPattern, nil)
 
 	// Register for UI visibility
@@ -706,8 +709,12 @@ func RouteList(server *ooo.Server, localPath string, cfg Config) error {
 	// the route oracle so the data wildcard defers to them regardless of
 	// registration order. AuditHandler wraps each so Server.Audit gates
 	// proxied requests the same way it gates built-in REST handlers.
-	server.Router.HandleFunc("/"+muxPattern, server.AuditHandler(itemHandler))
-	server.Router.HandleFunc("/"+basePath, server.AuditHandler(listHandler))
+	// RouterMutate serializes both mutations with the syncRouter
+	// wrapper's Match.
+	server.RouterMutate(func() {
+		server.Router.HandleFunc("/"+muxPattern, server.AuditHandler(itemHandler))
+		server.Router.HandleFunc("/"+basePath, server.AuditHandler(listHandler))
+	})
 	server.RegisterOracleRoute("/"+muxPattern, nil)
 	server.RegisterOracleRoute("/"+basePath, nil)
 
@@ -982,7 +989,9 @@ func RouteWithVars(server *ooo.Server, localPath string, cfg Config) error {
 		handleHTTPProxy(server, w, r, address, remotePath, cfg.Subscribe)
 	}
 
-	server.Router.HandleFunc("/"+localPath, server.AuditHandler(handler))
+	server.RouterMutate(func() {
+		server.Router.HandleFunc("/"+localPath, server.AuditHandler(handler))
+	})
 	server.RegisterOracleRoute("/"+localPath, nil)
 
 	// Register for UI visibility


### PR DESCRIPTION
Closes #106

## Summary
- `Server.routerMu sync.RWMutex` protects `Server.Router`.
- New `syncRouter` wrapper installed at `server.server.Handler` time takes `RLock` around `Match` and dispatches the matched handler WITHOUT the lock so long-running handlers (WS forwarders, hijacked conns) cannot block subsequent registrations.
- `Server.RouterMutate(fn)` takes the write `Lock` and runs `fn`. Every router-mutation site (`setupRoutes`, `Endpoint`, `proxy.Route`/`RouteList`/`RouteWithVars`) goes through it.

## Test plan
- [x] `TestServerRouterConcurrentEndpointAndServeHTTP` — 6 writers × 20 `Endpoint()` + 6 readers × 20 `http.Client.Get` behind a barrier, through the real HTTP server (`server.Address`). Pre-fix the race detector fires inside `gorilla/mux.(*Router).Match` vs `NewRoute`; post-fix race-clean. Verified by surgically reverting just the syncRouter wrap and keeping every other change — race re-appears, confirming the wrapper is load-bearing.
- [x] `go test ./... -race` clean across the workspace.

## Notes
- The wrapper has documented deviations from `mux.Router.ServeHTTP` — no path-cleaning + 301 redirect, no `Router.Use()` middleware fan-out, no `mux.CurrentRoute` setter. The codebase does not rely on any of these. Comments on `syncRouter` spell out what to add if a future consumer needs them.
- Self-review caught: my original `len(match.Vars) > 0` guard before `SetURLVars` diverged from mux (which always calls `requestWithVars`); fixed to always propagate.
- Self-review also flagged a path-cleaning regression — preserving mux's `cleanPath` behavior here would couple us to mux internals (`skipClean` / `useEncodedPath` are not exported), and the codebase does not depend on it. Chose to document the deviation rather than gold-plate.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)