### PR TITLE
fix(monotonic): atomic.Pointer the global clock so Reset is race-free

### DIFF
--- a/monotonic/clock.go
+++ b/monotonic/clock.go
@@ -1,7 +1,6 @@
 package monotonic
 
 import (
-	"sync"
 	"sync/atomic"
 	"time"
 )
@@ -26,18 +25,23 @@ type Clock struct {
 	stopCh    chan struct{}
 }
 
-// globalClock is the package-level singleton
-var globalClock *Clock
-
-// initOnce ensures Init() only creates the clock once
-var initOnce sync.Once
+// globalClock is the package-level singleton, accessed via atomic
+// load/store so a concurrent Reset cannot race with in-flight Now /
+// Stop callers. Init uses CAS so repeated calls are no-ops.
+var globalClock atomic.Pointer[Clock]
 
 // Init initializes the global monotonic clock instance.
 // Safe to call multiple times; only the first call has effect.
+// Safe to call concurrently with Now / Stop / Reset.
 func Init() {
-	initOnce.Do(func() {
-		globalClock = New()
-	})
+	if globalClock.Load() != nil {
+		return
+	}
+	fresh := New()
+	if !globalClock.CompareAndSwap(nil, fresh) {
+		// Lost the race; another goroutine initialized first.
+		fresh.Stop()
+	}
 }
 
 // New creates and starts a new monotonic clock
@@ -131,28 +135,31 @@ func (c *Clock) Stop() {
 // Now returns a monotonically increasing timestamp using the global clock.
 // Panics if Init() has not been called.
 func Now() int64 {
-	if globalClock == nil {
+	c := globalClock.Load()
+	if c == nil {
 		panic("monotonic: clock not initialized, call monotonic.Init() first")
 	}
-	return globalClock.Now()
+	return c.Now()
 }
 
 // Stop stops the global clock's correction loop.
 // Panics if Init() has not been called.
 func Stop() {
-	if globalClock == nil {
+	c := globalClock.Load()
+	if c == nil {
 		panic("monotonic: clock not initialized, call monotonic.Init() first")
 	}
-	globalClock.Stop()
+	c.Stop()
 }
 
-// Reset reinitializes the global clock (useful for testing).
-// This bypasses sync.Once to allow reinitialization.
+// Reset reinitializes the global clock (useful for testing). The
+// swap is atomic, so concurrent Now / Stop callers observe either
+// the old clock (and complete safely against it) or the new one,
+// never a torn pointer. The old clock is stopped after the swap so
+// no in-flight call references it as the current global.
 func Reset() {
-	if globalClock != nil {
-		globalClock.Stop()
+	old := globalClock.Swap(New())
+	if old != nil {
+		old.Stop()
 	}
-	globalClock = New()
-	// Reset initOnce so Init() can be called again if needed
-	initOnce = sync.Once{}
 }

--- a/monotonic/clock_test.go
+++ b/monotonic/clock_test.go
@@ -97,11 +97,47 @@ func BenchmarkMonotonicNowParallel(b *testing.B) {
 	})
 }
 
+// TestResetRaceWithConcurrentNow asserts the package-level
+// globalClock pointer is safe to swap (via Reset) while other
+// goroutines are calling Now(). Pre-fix Reset assigned globalClock
+// as a bare *Clock field while Now() read the same field without
+// synchronization — the race detector fires on any concurrent
+// Reset + Now. The fix wraps globalClock in atomic.Pointer so the
+// swap is atomic and stale readers continue safely on the old
+// clock until they finish their call.
+func TestResetRaceWithConcurrentNow(t *testing.T) {
+	Init()
+	const readers = 8
+	const iterations = 200
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(readers)
+	for range readers {
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					Now()
+				}
+			}
+		}()
+	}
+
+	for range iterations {
+		Reset()
+	}
+	close(stop)
+	wg.Wait()
+}
+
 func TestNowPanicWithoutInit(t *testing.T) {
 	// Save current globalClock and restore after test
-	original := globalClock
-	globalClock = nil
-	defer func() { globalClock = original }()
+	original := globalClock.Swap(nil)
+	defer globalClock.Store(original)
 
 	require.Panics(t, func() {
 		Now()
@@ -110,9 +146,8 @@ func TestNowPanicWithoutInit(t *testing.T) {
 
 func TestStopPanicWithoutInit(t *testing.T) {
 	// Save current globalClock and restore after test
-	original := globalClock
-	globalClock = nil
-	defer func() { globalClock = original }()
+	original := globalClock.Swap(nil)
+	defer globalClock.Store(original)
 
 	require.Panics(t, func() {
 		Stop()


### PR DESCRIPTION
Closes #108

## Summary
- `globalClock` becomes `atomic.Pointer[Clock]`.
- `Init` does load-then-CAS, dropping `sync.Once` entirely. Idempotent and race-free under contention (loser stops its fresh clock).
- `Reset` `Swap(New())` then `Stop` the old. Atomic — concurrent `Now`/`Stop` callers observe either the old (and complete safely) or the new clock, never a torn pointer.
- `Now` / `Stop` `Load(); nil → panic` — contract unchanged.

## Test plan
- [x] `TestResetRaceWithConcurrentNow` — 8 `Now` readers vs 200 `Reset` calls. Pre-fix the race detector fires inside `Reset` / `Now`; post-fix race-clean.
- [x] Existing `TestNowPanicWithoutInit` / `TestStopPanicWithoutInit` migrated to use `globalClock.Swap`/`Store`; still pass.
- [x] `go test ./... -race` clean across the workspace.

## Notes
Pre-flight self-review by a fresh sub-agent — zero blockers. Three deferred follow-ups noted:
- Concurrent `monotonic.Stop()` (no production caller) + `Reset()` can double-close the underlying `stopCh`. Pre-existing, not introduced by this diff. Worth a `sync.Once` on `Clock.Stop` later.
- `Clock.Stop` is not idempotent against itself either. Same fix would subsume it.
- The new race test leaves a fresh-from-Reset clock as the global. Other tests call `Init()` (idempotent) so order-independence holds today; flag for a future hygiene pass.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)