### PR TITLE
feat(server): expose Server.AfterWrite mirroring BeforeRead

### DIFF
--- a/ooo.go
+++ b/ooo.go
@@ -177,6 +177,10 @@ type audit func(r *http.Request) bool
 // OnStorageEvent: callback function triggered on storage events
 //
 // BeforeRead: callback function triggered before read operations
+//
+// AfterWrite: callback function triggered after a successful write
+// (Set / Push / Patch / Del). Wired once at Start; further changes
+// have no effect.
 type Server struct {
 	wg           sync.WaitGroup
 	watchWg      sync.WaitGroup
@@ -248,6 +252,7 @@ type Server struct {
 	OnWatchPanic        func(ev storage.Event, r any) // optional: invoked on each recovered watch-goroutine panic with the offending event
 	OnDroppedEvent      func(ev storage.Event)        // optional: invoked when the sharded watcher channel drops an event after timing out
 	BeforeRead          func(key string)
+	AfterWrite          func(key string)
 	GetPivotInfo        func() *ui.PivotInfo // Optional: returns pivot status for UI
 	NoCompress          bool                 // Disable gzip compression (useful for tests)
 	WatchPanics         int64                // Atomic counter of panics recovered in watch goroutines
@@ -413,6 +418,9 @@ func (server *Server) waitListen() {
 
 	if server.BeforeRead != nil {
 		storageOpt.BeforeRead = server.BeforeRead
+	}
+	if server.AfterWrite != nil {
+		storageOpt.AfterWrite = server.AfterWrite
 	}
 	err = server.Storage.Start(storageOpt)
 	if err != nil {

--- a/ooo_test.go
+++ b/ooo_test.go
@@ -147,6 +147,39 @@ func TestRouteOracleSkipAllowsConcurrentMatches(t *testing.T) {
 		"routeOracle matching must allow concurrent readers; max concurrent observed = %d", maxSeen.Load())
 }
 
+// TestServerAfterWriteFiresOnSet asserts that Server.AfterWrite —
+// mirroring the existing Server.BeforeRead field — is wired into the
+// storage layer at Start so a successful Set invokes the callback
+// with the written key. Pre-feature there was no Server-level
+// AfterWrite, only storage.Options.AfterWrite; pivot's sync-on-write
+// integration needs the Server entry point.
+func TestServerAfterWriteFiresOnSet(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+	var (
+		mu      sync.Mutex
+		written []string
+	)
+	server := Server{}
+	server.Silence = true
+	server.AfterWrite = func(key string) {
+		mu.Lock()
+		written = append(written, key)
+		mu.Unlock()
+	}
+	server.Start("localhost:0")
+	defer server.Close(os.Interrupt)
+
+	_, err := server.Storage.Set("k1", []byte(`{"v":1}`))
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, []string{"k1"}, written,
+		"Server.AfterWrite must fire with the written key once Set commits")
+}
+
 func TestDoubleStart(t *testing.T) {
 	server := Server{}
 	server.Silence = true


### PR DESCRIPTION
Closes #110

## Summary
- New `Server.AfterWrite func(key string)` field next to `Server.BeforeRead`.
- Plumbed once at `Start` into `storage.Options.AfterWrite` (storage layer was already wired through — every successful write fires the hook).
- Same lifecycle as `BeforeRead`: set at construction, ineffective if mutated post-Start. Documented.

## Test plan
- [x] `TestServerAfterWriteFiresOnSet` — configure callback, Start, `Storage.Set("k1", ...)`, assert callback fired with `k1`. Failing-premise verified by temporarily removing the plumb — test fails because the callback never fires.
- [x] `go test ./... -race` clean across the workspace.

## Notes
Pre-flight self-review surfaced one cosmetic: I had duplicate godoc for the new field (a header-block entry AND an inline). Dropped the inline to match the existing `BeforeRead` convention (header-block only). One deferred follow-up flagged: no `SetAfterWrite` runtime mutator, mirroring the asymmetry with `BeforeRead`'s `SetBeforeRead`. Not needed for the pivot consumer; would be a separate change if a future caller wants hot-reload of the hook.

Unblocks pivot's sync-on-write regression fix being landed in a parallel session.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)