### PR TITLE
fix(rest): drop stray body write after 204 No Content in unpublish

### DIFF
--- a/rest.go
+++ b/rest.go
@@ -234,7 +234,6 @@ func (server *Server) unpublish(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusNoContent)
-	w.Write([]byte(`"unpublish "+_key`))
 }
 
 // LimitBody wraps r.Body with http.MaxBytesReader so a runaway POST/PATCH

--- a/rest_test.go
+++ b/rest_test.go
@@ -176,6 +176,15 @@ func TestRestDel(t *testing.T) {
 	resp := w.Result()
 	data, _ := server.Storage.Get("test")
 	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	// 204 No Content forbids a response body per RFC 7230 §3.3.2.
+	// Pre-fix the handler wrote the literal Go-source string
+	// `"unpublish "+_key` after WriteHeader(204) — a real
+	// http.Server stripped it on the wire so users never saw it,
+	// but the handler-level invariant was broken. Co-locate this
+	// body assertion with the status check so the next regression
+	// in the same handler is caught here.
+	body, _ := io.ReadAll(resp.Body)
+	require.Empty(t, body, "204 No Content response must have an empty body; got %q", body)
 	require.Empty(t, data)
 
 	req = httptest.NewRequest("DELETE", "/test", nil)


### PR DESCRIPTION
Closes #112

## Summary
- Drop the stray `w.Write([]byte(\`"unpublish "+_key\`))` after `WriteHeader(http.StatusNoContent)` in `unpublish`.
- Fold the empty-body assertion into the existing `TestRestDel`'s 204-status check so the next regression in the same handler is caught at the same point.

## Test plan
- [x] `TestRestDel` now asserts `body == ""` alongside `status == 204`. Failing-premise verified by reverting just the rest.go change — assertion fires with the 17-byte literal `\"unpublish \"+_key`.
- [x] `go test ./... -race` clean across the workspace.

## Notes
Pre-flight self-review found no blockers. The reviewer pointed out that the bug "lived this long" because the body-side assertion was not co-located with the existing 204-status assertion — co-locating them is the discipline that would have caught this from day one. The reviewer also verified (and the commit message records) that pre-fix the bytes were stripped on the wire by net/http's real `Server`, so the user-visible impact was zero — but the handler-level invariant was real, and one refactor away from leaking.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)