### PR TITLE
fix(rest): return 404 when storage wraps not-found in a custom error

### DIFF
--- a/rest.go
+++ b/rest.go
@@ -13,6 +13,7 @@ import (
 	"github.com/benitogf/ooo/merge"
 	"github.com/benitogf/ooo/messages"
 	"github.com/benitogf/ooo/meta"
+	"github.com/benitogf/ooo/storage"
 	"github.com/benitogf/ooo/stream"
 	"github.com/gorilla/mux"
 )
@@ -224,7 +225,7 @@ func (server *Server) unpublish(w http.ResponseWriter, r *http.Request) {
 
 	if err != nil {
 		server.Console.Err(err.Error())
-		if err == ErrNotFound || strings.Contains(err.Error(), "not found") {
+		if errors.Is(err, storage.ErrNotFound) {
 			w.WriteHeader(http.StatusNotFound)
 		} else {
 			w.WriteHeader(http.StatusInternalServerError)

--- a/rest_test.go
+++ b/rest_test.go
@@ -14,8 +14,33 @@ import (
 	"github.com/benitogf/go-json"
 	"github.com/benitogf/ooo"
 	"github.com/benitogf/ooo/meta"
+	"github.com/benitogf/ooo/storage"
 	"github.com/stretchr/testify/require"
 )
+
+// maskedNotFound wraps storage.ErrNotFound but its Error() text omits
+// the literal "not found" substring. Used to exercise unpublish's
+// not-found detection path independently of message formatting.
+type maskedNotFound struct{ inner error }
+
+func (m maskedNotFound) Error() string { return "backend rejected delete" }
+func (m maskedNotFound) Unwrap() error { return m.inner }
+
+// wrapNotFoundStorage decorates a real Database so Del returns
+// maskedNotFound when the underlying layer reports ErrNotFound.
+// All other operations pass through unchanged.
+type wrapNotFoundStorage struct{ storage.Database }
+
+func (w *wrapNotFoundStorage) Del(key string) error {
+	err := w.Database.Del(key)
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, storage.ErrNotFound) {
+		return maskedNotFound{inner: storage.ErrNotFound}
+	}
+	return err
+}
 
 func TestRestPostNonObject(t *testing.T) {
 	if runtime.GOOS != "windows" {
@@ -210,6 +235,30 @@ func TestRestDel(t *testing.T) {
 	require.Error(t, err)
 	_, err = server.Storage.Get("test/2")
 	require.Error(t, err)
+}
+
+func TestRestDelNotFoundWrappedError(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+	server := ooo.Server{
+		Storage: &wrapNotFoundStorage{
+			Database: storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()}),
+		},
+	}
+	server.Silence = true
+	server.Start("localhost:0")
+	defer server.Close(os.Interrupt)
+
+	// Deleting a missing key surfaces storage.ErrNotFound wrapped in a
+	// custom error type whose message no longer contains "not found".
+	// The handler must still return 404 — detection has to use
+	// errors.Is against storage.ErrNotFound, not a substring match.
+	req := httptest.NewRequest("DELETE", "/missing", nil)
+	w := httptest.NewRecorder()
+	server.Router.ServeHTTP(w, req)
+	resp := w.Result()
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
 }
 
 func TestRestGet(t *testing.T) {


### PR DESCRIPTION
## Summary
Closes #114 — DELETE on a missing key now returns 404 regardless of how the storage backend wraps or formats its not-found signal.

- HTTP contract for DELETE on a missing key is honored even when the storage layer reshapes the not-found error.
- Detection is identity-based instead of message-text matching, so message-format changes downstream can't silently flip the response to 500.
- Regression coverage added: a wrapped not-found whose message omits "not found" still resolves to 404.

## Test plan
- [ ] DELETE on a missing key against the default backend returns 404.
- [ ] DELETE on a missing key against a backend that wraps its not-found in a custom error type also returns 404.
- [ ] Existing REST behavior unchanged for non-not-found errors (still 500) and successful deletes (still 204).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)