### PR TITLE
perf(stream): inline OnUnsubscribe on connection close

### DIFF
--- a/stream/stream.go
+++ b/stream/stream.go
@@ -434,7 +434,11 @@ func (sm *Stream) Close(key string, client *Conn) {
 		}
 	}
 	sm.mutex.Unlock()
-	go sm.OnUnsubscribe(key)
+	// Called inline: Close holds no locks here and the following client.conn.Close()
+	// is itself synchronous I/O, so a user callback that takes the same order of
+	// magnitude does not regress the path. Avoids spawning one goroutine per
+	// connection on bulk shutdown (thousands of conns → thousands of goroutines).
+	sm.OnUnsubscribe(key)
 	client.conn.Close()
 }
 
@@ -525,7 +529,10 @@ func (sm *Stream) broadcastPool(pool *Pool, data []byte, snapshot bool, version 
 	}
 	wg.Wait()
 
-	// Remove failed connections from pool while we still hold the pool lock
+	// Remove failed connections from pool while we still hold the pool lock.
+	// OnUnsubscribe is dispatched in a goroutine here (unlike Close) because the
+	// caller still holds pool.mutex; a slow callback would stall every broadcast
+	// reader on this pool.
 	for _, client := range failedConns {
 		pool.connections = removeConn(pool.connections, client)
 		go sm.OnUnsubscribe(pool.Key)


### PR DESCRIPTION
## Summary
Closes #120 — connection close no longer spawns a goroutine to deliver the unsubscribe callback; the broadcast-side dispatch keeps its goroutine to protect readers from slow callbacks.

- Bulk shutdown of N connections no longer schedules N extra goroutines for the callback path.
- User-supplied callbacks still see the same call shape; the close path was already synchronous around them.
- Broadcast-side dispatch is unchanged so a slow callback cannot stall readers holding the pool lock.

> Stacked on top of #119 (which is itself stacked on #117). Recommend reviewing/merging the chain in order; will rebase onto main once predecessors land.

## Test plan
- [ ] CI green on the stream package.
- [ ] CI green on the full repo suite.
- [ ] Existing OnSubscribe/OnUnsubscribe ws tests still pass.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)