### PR TITLE
fix(rest): encode publish/patch index response as JSON

### DIFF
--- a/rest.go
+++ b/rest.go
@@ -74,8 +74,7 @@ func (server *Server) publish(w http.ResponseWriter, r *http.Request) {
 
 	server.Console.Log("publish", _key)
 	server.filters.AfterWrite.Check(_key)
-	w.Header().Set("Content-Type", "application/json")
-	w.Write([]byte(`{"index":"` + index + `"}`))
+	writeIndexResponse(w, index)
 }
 
 func (server *Server) patch(w http.ResponseWriter, r *http.Request) {
@@ -150,8 +149,23 @@ func (server *Server) patch(w http.ResponseWriter, r *http.Request) {
 
 	server.Console.Log("patch", _key)
 	server.filters.AfterWrite.Check(_key)
+	writeIndexResponse(w, index)
+}
+
+// writeIndexResponse writes the canonical {"index":"..."} response body
+// using json.Marshal so JSON-significant characters in index do not
+// corrupt the response.
+func writeIndexResponse(w http.ResponseWriter, index string) {
+	body, err := json.Marshal(struct {
+		Index string `json:"index"`
+	}{Index: index})
+	if err != nil {
+		// json.Marshal of a string field cannot fail in practice; fall back
+		// to an empty object so the client still receives valid JSON.
+		body = []byte(`{}`)
+	}
 	w.Header().Set("Content-Type", "application/json")
-	w.Write([]byte(`{"index":"` + index + `"}`))
+	w.Write(body)
 }
 
 func (server *Server) read(w http.ResponseWriter, r *http.Request) {

--- a/rest_test.go
+++ b/rest_test.go
@@ -833,3 +833,81 @@ func TestRestGlobPatternEdgeCases(t *testing.T) {
 	resp = w.Result()
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }
+
+// quoteInjectingStorage wraps a Database and returns an index containing
+// a JSON-significant character (") from Set and Push. The handler's
+// {"index":"..."} response must encode via json.Marshal so the body
+// stays valid JSON even when the index is hostile to string concatenation.
+type quoteInjectingStorage struct{ storage.Database }
+
+func (q *quoteInjectingStorage) Set(k string, data json.RawMessage) (string, error) {
+	if _, err := q.Database.Set(k, data); err != nil {
+		return "", err
+	}
+	return `te"st`, nil
+}
+
+func (q *quoteInjectingStorage) Push(path string, data json.RawMessage) (string, error) {
+	if _, err := q.Database.Push(path, data); err != nil {
+		return "", err
+	}
+	return `te"st`, nil
+}
+
+func TestRestPublishResponseEncodesIndexAsJSON(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+	server := ooo.Server{
+		Storage: &quoteInjectingStorage{
+			Database: storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()}),
+		},
+	}
+	server.Silence = true
+	server.Start("localhost:0")
+	defer server.Close(os.Interrupt)
+
+	body := []byte(`{"data":"test"}`)
+	req := httptest.NewRequest(http.MethodPost, "/k", bytes.NewBuffer(body))
+	w := httptest.NewRecorder()
+	server.Router.ServeHTTP(w, req)
+	resp := w.Result()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	respBody, _ := io.ReadAll(resp.Body)
+	var parsed struct {
+		Index string `json:"index"`
+	}
+	require.NoError(t, json.Unmarshal(respBody, &parsed), "response must be valid JSON, got: %s", respBody)
+	require.Equal(t, `te"st`, parsed.Index)
+}
+
+func TestRestPatchResponseEncodesIndexAsJSON(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
+	server := ooo.Server{
+		Storage: &quoteInjectingStorage{
+			Database: storage.New(storage.LayeredConfig{Memory: storage.NewMemoryLayer()}),
+		},
+	}
+	server.Silence = true
+	server.Start("localhost:0")
+	defer server.Close(os.Interrupt)
+
+	// Seed the key so PATCH has something to merge against.
+	_, err := server.Storage.Set("k", json.RawMessage(`{"a":1}`))
+	require.NoError(t, err)
+
+	body := []byte(`{"b":2}`)
+	req := httptest.NewRequest(http.MethodPatch, "/k", bytes.NewBuffer(body))
+	w := httptest.NewRecorder()
+	server.Router.ServeHTTP(w, req)
+	resp := w.Result()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	respBody, _ := io.ReadAll(resp.Body)
+	var parsed struct {
+		Index string `json:"index"`
+	}
+	require.NoError(t, json.Unmarshal(respBody, &parsed), "response must be valid JSON, got: %s", respBody)
+	require.Equal(t, `te"st`, parsed.Index)
+}


### PR DESCRIPTION
## Summary
Closes #122 — publish and patch responses are now encoded via `json.Marshal` instead of string concatenation, so the body stays valid JSON even if the storage layer returns an index containing characters that need escaping.

- Response field, field name, and `Content-Type` unchanged for the happy path.
- Locked in by a regression test that wraps storage to inject a hostile index (`te"st`) and asserts the response parses cleanly through `json.Unmarshal`.
- The same regression test fails against the pre-fix code (response body `{"index":"te"st"}` is invalid JSON), proving the contract is now enforced.

## Test plan
- [ ] CI green on the rest package.
- [ ] CI green on the full repo suite.
- [ ] New regression tests for both POST and PATCH pass.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)