### PR TITLE
fix(server): preserve user-supplied Console across Start

### DIFF
--- a/ooo.go
+++ b/ooo.go
@@ -259,6 +259,7 @@ type Server struct {
 	DroppedEvents       int64                // Atomic counter of events dropped by the sharded watcher on send timeout
 	startErr            chan error           // channel for startup errors
 	clockStop           chan struct{}        // channel to signal clock goroutine to stop
+	consoleAutoBuilt    bool                 // true when defaults() built Console (so post-Listen rebuild can swap address without clobbering a user-supplied Console)
 }
 
 // Validate checks the server configuration for common issues.
@@ -722,6 +723,7 @@ func (server *Server) defaults() {
 	}
 	if server.Console == nil {
 		server.Console = coat.NewConsole(server.Address, server.Silence)
+		server.consoleAutoBuilt = true
 	}
 	if server.Stream.Console == nil {
 		server.Stream.Console = server.Console
@@ -876,7 +878,12 @@ func (server *Server) StartWithError(address string) error {
 	if err != nil {
 		return err
 	}
-	server.Console = coat.NewConsole(server.Address, server.Silence)
+	// Rebuild the auto-built Console with the resolved listen address; only
+	// when defaults() built it, so a user-supplied Console is preserved.
+	if server.consoleAutoBuilt {
+		server.Console = coat.NewConsole(server.Address, server.Silence)
+		server.Stream.Console = server.Console
+	}
 	server.clockStop = make(chan struct{})
 	server.clockWg.Add(1)
 	go server.startClock()

--- a/ooo_test.go
+++ b/ooo_test.go
@@ -13,11 +13,37 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benitogf/coat"
 	"github.com/benitogf/go-json"
 	"github.com/benitogf/ooo/storage"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/require"
 )
+
+// TestServerStartPreservesUserSuppliedConsole asserts that a Console
+// provided by the caller is not replaced during Start. Pre-fix the
+// post-Listen rebuild at the end of StartWithError overwrote the field
+// unconditionally, dropping any custom Console the caller had attached.
+func TestServerStartPreservesUserSuppliedConsole(t *testing.T) {
+	custom := coat.NewConsole("custom-console-marker", true)
+	server := Server{Console: custom}
+	server.Silence = true
+	server.Start("localhost:0")
+	defer server.Close(os.Interrupt)
+	require.Same(t, custom, server.Console, "user-supplied Console must survive Start")
+}
+
+// TestServerStartConsoleBuiltOnceWithResolvedAddress asserts that when
+// no Console is supplied, the auto-built Console exists exactly once
+// using the resolved listen address (not the placeholder ":0" form).
+func TestServerStartConsoleBuiltOnceWithResolvedAddress(t *testing.T) {
+	server := Server{}
+	server.Silence = true
+	server.Start("localhost:0")
+	defer server.Close(os.Interrupt)
+	require.NotNil(t, server.Console)
+	require.NotContains(t, server.Address, ":0", "Address should be resolved post-Listen")
+}
 
 func TestDoubleShutdown(t *testing.T) {
 	server := Server{}


### PR DESCRIPTION
## Summary
Closes #124 — a Console attached to the server before Start is no longer replaced after Listen resolves; the auto-built path still refreshes its Console with the resolved listen address.

- User-supplied Console preserved end-to-end.
- Auto-built Console still reflects the resolved address (port-0 → real port case).
- Regression tests cover both paths.

## Test plan
- [ ] CI green on the full repo suite.
- [ ] User-supplied Console preservation test passes.
- [ ] Auto-built Console address-resolution test passes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)