### PR TITLE
docs(close): describe Close teardown bounds + SIGKILL contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,3 +466,40 @@ ooo includes a built-in web-based ui to manage and monitor your data. The ui is 
 - **Static Mode** - Traditional CRUD operations with JSON editor
 - **State Monitor** - View active WebSocket connections and subscriptions
 - **Filter Management** - Visual representation of filter types (open, read-only, write-only, custom, limit)
+
+
+## Shutdown & durability
+
+`server.Close(sig)` runs a bounded graceful shutdown: it drains in-flight HTTP requests up to `Server.Deadline`, closes WebSocket connections, closes the storage backend, and runs any user-supplied teardown callbacks. `server.WaitClose()` is the convenience wrapper that blocks on SIGINT / SIGTERM / SIGHUP and then calls `Close` with the received signal.
+
+### SIGKILL is uncatchable
+
+POSIX requires SIGKILL (and SIGSTOP) to be delivered by the kernel with no opportunity for user code to run. When SIGKILL arrives:
+
+- No deferred functions execute. `Close` does not run. `OnClose` does not run.
+- Any queued broadcasts, watcher events, and writes that the storage backend has not yet flushed to durable media are lost.
+- Connected subscribers receive a TCP RST and re-fetch state on reconnect.
+
+Durability across hard kill is the responsibility of the storage backend, not of `Server.Close`. Pick a backend whose contract you trust and budget your shutdown window so SIGKILL never has to fire under normal operation.
+
+### Orchestrator configuration
+
+The orchestrator should send SIGTERM first and grant a grace window at least as long as `Server.Deadline` plus the worst-case runtime of every user-supplied callback (preClose, proxy, OnClose). SIGKILL should be the orchestrator's stuck-teardown fallback, not the primary shutdown path.
+
+On Kubernetes, set `terminationGracePeriodSeconds` accordingly. The default of 30s is enough for most configurations; raise it if you've increased `Server.Deadline` or if your callbacks flush sizable state.
+
+### Teardown callbacks
+
+`Server` exposes three places to register teardown code, each running at a different point in `Close`:
+
+| Hook | When it runs | Storage / stream / HTTP state | Typical use |
+|---|---|---|---|
+| `AddPreCloseCleanup(fn)` | First, before any tear-down | All up | Flush in-memory state to storage, broadcast a "shutting down" message |
+| `AddProxyCleanup(fn)` | After preClose, before the stream closes | Stream still up | Unsubscribe from upstream proxy servers |
+| `OnClose` (field) | Last, after everything else is closed | All torn down | Close user-owned resources (DB pools, log handles) |
+
+Callbacks run synchronously and `Close` blocks until each returns. Today there is **no aggregate timeout** on user callbacks — a callback that hangs hangs `Close`, which can push the orchestrator past `terminationGracePeriodSeconds` and trigger SIGKILL. Keep callbacks short, or make them respect their own timeouts.
+
+### Custom Endpoint handlers
+
+HTTP handlers registered via `server.Endpoint` are not wrapped in a request timeout. During shutdown they receive a cancellation through `r.Context().Done()` once `Server.Deadline` elapses, but a handler that ignores its context will keep running and Go cannot kill it. Always check `r.Context().Done()` in long-running custom handlers if you want them to exit cleanly during shutdown.

--- a/README.md
+++ b/README.md
@@ -494,8 +494,8 @@ On Kubernetes, set `terminationGracePeriodSeconds` accordingly. The default of 3
 
 | Hook | When it runs | Storage / stream / HTTP state | Typical use |
 |---|---|---|---|
-| `AddPreCloseCleanup(fn)` | First, before any tear-down | All up | Flush in-memory state to storage, broadcast a "shutting down" message |
-| `AddProxyCleanup(fn)` | After preClose, before the stream closes | Stream still up | Unsubscribe from upstream proxy servers |
+| `RegisterPreClose(fn)` | First, before any tear-down | All up | Flush in-memory state to storage, broadcast a "shutting down" message |
+| `RegisterProxyCleanup(fn)` | After preClose, before the stream closes | Stream still up | Unsubscribe from upstream proxy servers |
 | `OnClose` (field) | Last, after everything else is closed | All torn down | Close user-owned resources (DB pools, log handles) |
 
 Callbacks run synchronously and `Close` blocks until each returns. Today there is **no aggregate timeout** on user callbacks — a callback that hangs hangs `Close`, which can push the orchestrator past `terminationGracePeriodSeconds` and trigger SIGKILL. Keep callbacks short, or make them respect their own timeouts.

--- a/ooo.go
+++ b/ooo.go
@@ -910,12 +910,12 @@ func (server *Server) Start(address string) {
 //
 //  1. Mark the server as closing (atomic, idempotent — second concurrent
 //     call returns immediately).
-//  2. Run preClose cleanups (registered via Server.AddPreCloseCleanup).
+//  2. Run preClose cleanups (registered via Server.RegisterPreClose).
 //     Storage, stream, and HTTP are still up — callbacks may broadcast,
 //     read, or write.
 //  3. Stop the internal clock goroutine (bounded — clock selects on a
 //     stop channel).
-//  4. Run proxy cleanups (registered via Server.AddProxyCleanup).
+//  4. Run proxy cleanups (registered via Server.RegisterProxyCleanup).
 //  5. Close all WebSocket connections (bounded — per-connection TCP close).
 //  6. Stop the HTTP server: graceful shutdown with a context bounded by
 //     Server.Deadline (default 10s), then force-close to cancel any
@@ -932,8 +932,9 @@ func (server *Server) Start(address string) {
 // Bound:
 //
 //   - HTTP request drain: bounded by Server.Deadline.
-//   - Internal waitgroups (clock, listen, watch, handler-for-cooperative-handlers):
-//     bounded by their own stop signals.
+//   - Internal waitgroups (clock, listen, watch): bounded by their own
+//     stop signals. The handler waitgroup is bounded only for handlers
+//     that respect r.Context().Done(); see below.
 //   - Storage.Close: bounded for in-tree layers; depends on the bottom-layer
 //     contract for embedded storages (e.g. ko, nopog).
 //   - preClose cleanups, proxy cleanups, and OnClose: NOT bounded. They

--- a/ooo.go
+++ b/ooo.go
@@ -901,7 +901,52 @@ func (server *Server) Start(address string) {
 	}
 }
 
-// Close : shutdown the http server and database connection.
+// Close runs the graceful shutdown sequence: drains in-flight HTTP
+// requests up to Server.Deadline, closes all WebSocket connections,
+// closes the storage backend, and invokes user-supplied callbacks at
+// well-defined points.
+//
+// Teardown sequence (in order):
+//
+//  1. Mark the server as closing (atomic, idempotent — second concurrent
+//     call returns immediately).
+//  2. Run preClose cleanups (registered via Server.AddPreCloseCleanup).
+//     Storage, stream, and HTTP are still up — callbacks may broadcast,
+//     read, or write.
+//  3. Stop the internal clock goroutine (bounded — clock selects on a
+//     stop channel).
+//  4. Run proxy cleanups (registered via Server.AddProxyCleanup).
+//  5. Close all WebSocket connections (bounded — per-connection TCP close).
+//  6. Stop the HTTP server: graceful shutdown with a context bounded by
+//     Server.Deadline (default 10s), then force-close to cancel any
+//     still-running request contexts. Handlers that honour
+//     r.Context().Done() exit then; handlers that ignore the context
+//     leak (Go cannot kill them).
+//  7. Wait for HTTP handlers and the listen goroutine to exit.
+//  8. Close the storage backend.
+//  9. Wait for storage-watcher goroutines (bounded — they exit when
+//     storage closes their channels).
+//  10. Run Server.OnClose. Storage, stream, and HTTP are all torn down —
+//     use this for closing user-owned resources only.
+//
+// Bound:
+//
+//   - HTTP request drain: bounded by Server.Deadline.
+//   - Internal waitgroups (clock, listen, watch, handler-for-cooperative-handlers):
+//     bounded by their own stop signals.
+//   - Storage.Close: bounded for in-tree layers; depends on the bottom-layer
+//     contract for embedded storages (e.g. ko, nopog).
+//   - preClose cleanups, proxy cleanups, and OnClose: NOT bounded. They
+//     run synchronously and Close blocks until each returns. Keep them
+//     short — the orchestrator's SIGTERM-to-SIGKILL window has to cover
+//     Deadline plus the worst case across all of them.
+//   - HTTP handlers that ignore r.Context().Done(): NOT bounded. They
+//     can outlive Close. Custom Endpoint handlers in particular must
+//     check the context.
+//
+// Hard-kill: SIGKILL is uncatchable; nothing in this sequence runs.
+// See WaitClose for the SIGTERM/SIGKILL contract operators should
+// configure for.
 //
 // Safe to call from multiple goroutines: an atomic CompareAndSwap on
 // `closing` lets only the first caller through; concurrent callers
@@ -959,7 +1004,24 @@ func (server *Server) Close(sig os.Signal) {
 	}
 }
 
-// WaitClose : Blocks waiting for SIGINT, SIGTERM, SIGKILL, SIGHUP
+// WaitClose blocks until the process receives SIGINT, SIGTERM, or SIGHUP
+// and then runs the graceful Close sequence with the received signal.
+//
+// SIGKILL is intentionally not listed. POSIX requires SIGKILL (and
+// SIGSTOP) to be uncatchable: the kernel terminates the process with
+// no opportunity for user code to run, so no defers, no Close, no
+// OnClose, and no user callbacks execute. Anything sitting in
+// in-process buffers (queued broadcasts, watcher events, writes that
+// the storage backend has not yet flushed to durable media) is lost
+// when SIGKILL is delivered. Durability across hard kill is the
+// responsibility of the storage backend, not Server.Close.
+//
+// Operators should configure their orchestrator to send SIGTERM first
+// and grant a grace window at least as long as Server.Deadline plus
+// the worst-case runtime of any user-supplied preClose / proxy /
+// OnClose callback. On Kubernetes this is `terminationGracePeriodSeconds`.
+// SIGKILL should be the orchestrator's fallback for a stuck
+// SIGTERM teardown, not the primary shutdown path.
 func (server *Server) WaitClose() {
 	server.Signal = make(chan os.Signal, 1)
 	done := make(chan bool, 1)

--- a/ooo.go
+++ b/ooo.go
@@ -932,9 +932,15 @@ func (server *Server) Start(address string) {
 // Bound:
 //
 //   - HTTP request drain: bounded by Server.Deadline.
-//   - Internal waitgroups (clock, listen, watch): bounded by their own
-//     stop signals. The handler waitgroup is bounded only for handlers
-//     that respect r.Context().Done(); see below.
+//   - Internal waitgroups (clock, listen, watch, handler): bounded.
+//     Clock selects on clockStop, watch goroutines exit when storage
+//     closes their channels, the listen goroutine exits when the HTTP
+//     server's listener is force-closed at step 6, and the handler
+//     waitgroup only tracks the long-lived clock long-poll and
+//     WebSocket handlers — both of which exit when Stream.CloseAll
+//     closes their connections at step 5. REST publish / read / patch /
+//     unpublish and custom Endpoint handlers are not tracked by the
+//     handler waitgroup; see the next bullet for how they're bounded.
 //   - Storage.Close: bounded for in-tree layers; depends on the bottom-layer
 //     contract for embedded storages (e.g. ko, nopog).
 //   - preClose cleanups, proxy cleanups, and OnClose: NOT bounded. They

--- a/ooo_test.go
+++ b/ooo_test.go
@@ -360,6 +360,11 @@ func TestCloseMarksServerInactive(t *testing.T) {
 func TestServerCloseHealthyPathReturnsPromptly(t *testing.T) {
 	server := &Server{Silence: true}
 	server.Start("localhost:0")
+	// Defensive deferred Close so a failing require below does not leak
+	// the listener and the clock / watch / listen goroutines. The
+	// explicit Close below runs first; the deferred call is a no-op via
+	// the closing-atomic CAS in Close.
+	defer server.Close(os.Interrupt)
 
 	// Drive a few normal requests so the storage watcher and broadcast
 	// path see real traffic before tear-down, rather than running the

--- a/ooo_test.go
+++ b/ooo_test.go
@@ -344,6 +344,41 @@ func TestCloseMarksServerInactive(t *testing.T) {
 	require.False(t, server.Active())
 }
 
+// TestServerCloseHealthyPathReturnsPromptly is a regression guard: on a
+// healthy path (no stuck handlers, no user callbacks registered) Close
+// must complete in well under a second. Internal teardown is sequenced
+// by clockWg / listenWg / handlerWg / watchWg, all of which become
+// signalable as soon as the listener is force-closed and the storage
+// watcher channels are closed. If a future change adds a new internal
+// wait that can stretch into the second-scale on a healthy path, this
+// test will fail.
+//
+// Out of scope here: stuck custom Endpoint handlers (covered by
+// TestServerCloseShutdownBoundedByDeadline) and user-supplied
+// preClose/proxy/OnClose callbacks, which are bounded by user contract,
+// not by Close itself.
+func TestServerCloseHealthyPathReturnsPromptly(t *testing.T) {
+	server := &Server{Silence: true}
+	server.Start("localhost:0")
+
+	// Drive a couple of normal requests so the handlerWg has actually
+	// counted up and back down, exercising the full path rather than
+	// the zero-traffic shortcut.
+	for range 3 {
+		req := httptest.NewRequest(http.MethodPost, "/k", bytes.NewBuffer([]byte(`{"v":1}`)))
+		w := httptest.NewRecorder()
+		server.Router.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Result().StatusCode)
+	}
+
+	start := time.Now()
+	server.Close(os.Interrupt)
+	elapsed := time.Since(start)
+
+	require.Less(t, elapsed, 500*time.Millisecond,
+		"healthy-path Close returned in %s; suspect a new unbounded step in Close()", elapsed)
+}
+
 // TestServerCloseShutdownBoundedByDeadline asserts that Server.Close does not
 // hang forever on a stuck HTTP handler. The shutdown context must be bounded
 // by server.Deadline. Pre-fix, Shutdown(context.Background()) waited for the

--- a/ooo_test.go
+++ b/ooo_test.go
@@ -361,9 +361,14 @@ func TestServerCloseHealthyPathReturnsPromptly(t *testing.T) {
 	server := &Server{Silence: true}
 	server.Start("localhost:0")
 
-	// Drive a couple of normal requests so the handlerWg has actually
-	// counted up and back down, exercising the full path rather than
-	// the zero-traffic shortcut.
+	// Drive a few normal requests so the storage watcher and broadcast
+	// path see real traffic before tear-down, rather than running the
+	// zero-traffic shortcut. handlerWg is only incremented by the clock
+	// and WebSocket handlers, not by REST publish, so REST traffic
+	// alone does not exercise the HTTP-handler join — but it does
+	// exercise Storage.Set, the watch goroutines, and the stream
+	// broadcast pipeline, which is the surface most likely to grow a
+	// new unbounded wait.
 	for range 3 {
 		req := httptest.NewRequest(http.MethodPost, "/k", bytes.NewBuffer([]byte(`{"v":1}`)))
 		w := httptest.NewRecorder()


### PR DESCRIPTION
## Summary
Closes #126 — operators now have a complete contract for `server.Close` and what `WaitClose` does on each signal type.

- `WaitClose` godoc: drops the SIGKILL claim, describes the SIGTERM-first orchestrator contract operators should configure.
- `Close` godoc: enumerates the 10-step teardown sequence and labels each step as bounded by `Deadline`, bounded by an internal stop signal, or unbounded by user contract. The "internal waitgroups" bullet names each waitgroup's stop signal explicitly so the handler-side bound is unambiguous.
- README: new "Shutdown & durability" section covering SIGKILL semantics, Kubernetes `terminationGracePeriodSeconds`, the three callback registration hooks (`RegisterPreClose`, `RegisterProxyCleanup`, `OnClose`), and the custom-Endpoint handler context-respect requirement.
- New regression test asserts a healthy-path `Close` returns in well under 500 ms, so a future change that quietly adds an unbounded internal step will fail CI instead of slipping through. The test defers a Close so a require failure in setup still tears the server down cleanly.

No behaviour change. The teardown sequence and bounds are unchanged from PR #63 — this PR documents what was already true.

## Test plan
- [x] `go test ./...` passes locally (full suite green).
- [x] Healthy-path `Close` completes in under 500 ms (`TestServerCloseHealthyPathReturnsPromptly`); passes 5/5 and under `-race`.
- [x] Existing `TestServerCloseShutdownBoundedByDeadline` and `TestServerCloseCancelsHandlerContext` still pass under `-race`.
- [ ] godoc rendered cleanly via `go doc -all` (visual check on `WaitClose` + `Close`).
- [ ] README "Shutdown & durability" section renders correctly on GitHub.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)