### PR TITLE
refactor(ooo): move test helpers to sibling oootest package

### DIFF
--- a/filters_test.go
+++ b/filters_test.go
@@ -68,6 +68,8 @@ func TestFilters(t *testing.T) {
 		notified = true
 	})
 
+	postBody := json.RawMessage(`{"value":"any"}`)
+
 	server.Start("localhost:0")
 	defer server.Close(os.Interrupt)
 	_, err := server.filters.Write.Check("test/1", unacceptedData, false)
@@ -101,7 +103,7 @@ func TestFilters(t *testing.T) {
 	require.NoError(t, err)
 	_, err = server.filters.ReadList.Check("book/1", nil, true)
 	require.NoError(t, err)
-	req := httptest.NewRequest("POST", "/test/1", bytes.NewBuffer(TEST_DATA))
+	req := httptest.NewRequest("POST", "/test/1", bytes.NewBuffer(postBody))
 	w := httptest.NewRecorder()
 	server.Router.ServeHTTP(w, req)
 	resp := w.Result()
@@ -113,7 +115,7 @@ func TestFilters(t *testing.T) {
 	resp = w.Result()
 	require.Equal(t, 200, resp.StatusCode)
 
-	req = httptest.NewRequest("POST", "/flyer", bytes.NewBuffer(TEST_DATA))
+	req = httptest.NewRequest("POST", "/flyer", bytes.NewBuffer(postBody))
 	w = httptest.NewRecorder()
 	server.Router.ServeHTTP(w, req)
 	resp = w.Result()

--- a/memory_bench_test.go
+++ b/memory_bench_test.go
@@ -1,17 +1,20 @@
-package ooo
+package ooo_test
 
 import (
 	"os"
 	"testing"
+
+	"github.com/benitogf/ooo"
+	"github.com/benitogf/ooo/oootest"
 )
 
 // go test -bench=.
 
 func BenchmarkMemoryStorageSetGetDel(b *testing.B) {
 	b.ReportAllocs()
-	server := Server{}
+	server := ooo.Server{}
 	server.Silence = true
 	server.Start("localhost:9889")
 	defer server.Close(os.Interrupt)
-	StorageSetGetDelTestBenchmark(server.Storage, b)
+	oootest.StorageSetGetDelTestBenchmark(server.Storage, b)
 }

--- a/memory_test.go
+++ b/memory_test.go
@@ -1,4 +1,4 @@
-package ooo
+package ooo_test
 
 import (
 	"context"
@@ -8,8 +8,10 @@ import (
 	"testing"
 
 	"github.com/benitogf/go-json"
+	"github.com/benitogf/ooo"
 	"github.com/benitogf/ooo/client"
 	"github.com/benitogf/ooo/monotonic"
+	"github.com/benitogf/ooo/oootest"
 	"github.com/benitogf/ooo/storage"
 	"github.com/stretchr/testify/require"
 )
@@ -22,12 +24,12 @@ func TestStorage(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Parallel()
 	}
-	app := &Server{}
+	app := &ooo.Server{}
 	app.Silence = true
 	app.Start("localhost:0")
 	defer app.Close(os.Interrupt)
-	StorageListTest(app, t)
-	StorageObjectTest(app, t)
+	oootest.StorageListTest(app, t)
+	oootest.StorageObjectTest(app, t)
 }
 
 // TestSubscribeExtendedKeyChars asserts that a client can subscribe to keys
@@ -49,7 +51,7 @@ func TestSubscribeExtendedKeyChars(t *testing.T) {
 	}
 	for _, k := range keys {
 		t.Run(k, func(t *testing.T) {
-			server := &Server{}
+			server := &ooo.Server{}
 			server.Silence = true
 			server.Start("localhost:0")
 			defer server.Close(os.Interrupt)
@@ -94,7 +96,7 @@ func TestSubscribeListExtendedKeyChars(t *testing.T) {
 	type payload struct {
 		Name string `json:"name"`
 	}
-	server := &Server{}
+	server := &ooo.Server{}
 	server.Silence = true
 	server.Start("localhost:0")
 	defer server.Close(os.Interrupt)
@@ -138,7 +140,7 @@ func TestStorageExtendedKeyChars(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Parallel()
 	}
-	app := &Server{}
+	app := &ooo.Server{}
 	app.Silence = true
 	app.Start("localhost:0")
 	defer app.Close(os.Interrupt)
@@ -152,7 +154,7 @@ func TestStorageExtendedKeyChars(t *testing.T) {
 	}
 
 	for _, k := range keys {
-		_, err := app.Storage.Set(k, TEST_DATA)
+		_, err := app.Storage.Set(k, oootest.TEST_DATA)
 		require.NoError(t, err, "Set %q", k)
 
 		obj, err := app.Storage.Get(k)
@@ -177,158 +179,158 @@ func TestStreamBroadcast(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Parallel()
 	}
-	server := Server{}
+	server := ooo.Server{}
 	server.Silence = true
 	server.ForcePatch = true
 	server.Start("localhost:0")
 	defer server.Close(os.Interrupt)
-	StreamBroadcastTest(t, &server)
+	oootest.StreamBroadcastTest(t, &server)
 }
 
 func TestStreamGlobBroadcast(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Parallel()
 	}
-	server := Server{}
+	server := ooo.Server{}
 	server.Silence = true
 	server.ForcePatch = true
 	server.Start("localhost:0")
 	defer server.Close(os.Interrupt)
-	StreamGlobBroadcastTest(t, &server, 3)
+	oootest.StreamGlobBroadcastTest(t, &server, 3)
 }
 
 func TestStreamGlobBroadcastConcurrent(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Parallel()
 	}
-	server := Server{}
+	server := ooo.Server{}
 	server.Silence = true
 	server.ForcePatch = true
 	server.Start("localhost:0")
 	defer server.Close(os.Interrupt)
-	StreamGlobBroadcastConcurrentTest(t, &server, 3)
+	oootest.StreamGlobBroadcastConcurrentTest(t, &server, 3)
 }
 
 func TestStreamBroadcastFilter(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Parallel()
 	}
-	server := Server{}
+	server := ooo.Server{}
 	server.Silence = true
 	server.ForcePatch = true
 	defer server.Close(os.Interrupt)
-	StreamBroadcastFilterTest(t, &server)
+	oootest.StreamBroadcastFilterTest(t, &server)
 }
 
 func TestStreamForcePatch(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Parallel()
 	}
-	server := Server{}
+	server := ooo.Server{}
 	server.Silence = true
 	defer server.Close(os.Interrupt)
-	StreamBroadcastForcePatchTest(t, &server)
+	oootest.StreamBroadcastForcePatchTest(t, &server)
 }
 
 func TestStreamNoPatch(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Parallel()
 	}
-	server := Server{}
+	server := ooo.Server{}
 	server.Silence = true
 	defer server.Close(os.Interrupt)
-	StreamBroadcastNoPatchTest(t, &server)
+	oootest.StreamBroadcastNoPatchTest(t, &server)
 }
 
 func TestGetN(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Parallel()
 	}
-	server := &Server{}
+	server := &ooo.Server{}
 	server.Silence = true
 	server.Start("localhost:0")
 	defer server.Close(os.Interrupt)
-	StorageGetNTest(server, t, 10)
+	oootest.StorageGetNTest(server, t, 10)
 }
 
 func TestGetNRange(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Parallel()
 	}
-	server := &Server{}
+	server := &ooo.Server{}
 	server.Silence = true
 	server.Start("localhost:0")
 	defer server.Close(os.Interrupt)
-	StorageGetNRangeTest(server, t, 10)
+	oootest.StorageGetNRangeTest(server, t, 10)
 }
 
 func TestKeysRange(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Parallel()
 	}
-	server := &Server{}
+	server := &ooo.Server{}
 	server.Silence = true
 	server.Start("localhost:0")
 	defer server.Close(os.Interrupt)
-	StorageKeysRangeTest(server, t, 10)
+	oootest.StorageKeysRangeTest(server, t, 10)
 }
 
 func TestStreamItemGlobBroadcast(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Parallel()
 	}
-	server := Server{}
+	server := ooo.Server{}
 	server.Silence = true
 	server.ForcePatch = true
 	server.Start("localhost:0")
 	server.Storage.Clear()
 	defer server.Close(os.Interrupt)
-	StreamItemGlobBroadcastTest(t, &server)
+	oootest.StreamItemGlobBroadcastTest(t, &server)
 }
 
 func TestBatchSet(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Parallel()
 	}
-	server := &Server{}
+	server := &ooo.Server{}
 	server.Silence = true
 	server.Start("localhost:0")
 	defer server.Close(os.Interrupt)
-	StorageBatchSetTest(server, t, 10)
+	oootest.StorageBatchSetTest(server, t, 10)
 }
 
 func TestStreamPatch(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Parallel()
 	}
-	server := &Server{}
+	server := &ooo.Server{}
 	server.Silence = true
 	server.Start("localhost:0")
 	defer server.Close(os.Interrupt)
-	StreamBroadcastPatchTest(t, server)
+	oootest.StreamBroadcastPatchTest(t, server)
 }
 
 func TestStreamLimitFilter(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Parallel()
 	}
-	server := &Server{}
+	server := &ooo.Server{}
 	server.Silence = true
 	server.Start("localhost:0")
 	defer server.Close(os.Interrupt)
-	StreamLimitFilterTest(t, server)
+	oootest.StreamLimitFilterTest(t, server)
 }
 
 func TestClientCompatibility(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Parallel()
 	}
-	server := &Server{}
+	server := &ooo.Server{}
 	server.Silence = true
 	server.ForcePatch = true
 	server.Start("localhost:0")
 	defer server.Close(os.Interrupt)
-	ClientCompatibilityTest(t, server)
+	oootest.ClientCompatibilityTest(t, server)
 }
 
 func TestBeforeRead(t *testing.T) {
@@ -341,7 +343,7 @@ func TestBeforeRead(t *testing.T) {
 	err := db.Start(storage.Options{})
 	require.NoError(t, err)
 	defer db.Close()
-	StorageBeforeReadTest(db, t)
+	oootest.StorageBeforeReadTest(db, t)
 }
 
 func TestStorageAfterWrite(t *testing.T) {
@@ -354,7 +356,7 @@ func TestStorageAfterWrite(t *testing.T) {
 	err := db.Start(storage.Options{})
 	require.NoError(t, err)
 	defer db.Close()
-	StorageAfterWriteTest(db, t)
+	oootest.StorageAfterWriteTest(db, t)
 }
 
 func TestWatchStorageNoop(t *testing.T) {
@@ -367,5 +369,5 @@ func TestWatchStorageNoop(t *testing.T) {
 	err := db.Start(storage.Options{})
 	require.NoError(t, err)
 	defer db.Close()
-	WatchStorageNoopTest(db, t)
+	oootest.WatchStorageNoopTest(db, t)
 }

--- a/oootest/storage.go
+++ b/oootest/storage.go
@@ -1,4 +1,4 @@
-package ooo
+package oootest
 
 import (
 	"bytes"
@@ -12,6 +12,7 @@ import (
 	"github.com/benitogf/go-json"
 
 	"github.com/benitogf/jsondiff"
+	"github.com/benitogf/ooo"
 	"github.com/benitogf/ooo/key"
 	"github.com/benitogf/ooo/meta"
 	"github.com/benitogf/ooo/monotonic"
@@ -856,7 +857,7 @@ var TEST_DATA_UPDATE = json.RawMessage(`{
   }`)
 
 // StorageObjectTest testing storage function
-func StorageObjectTest(server *Server, t *testing.T) {
+func StorageObjectTest(server *ooo.Server, t *testing.T) {
 	server.Storage.Clear()
 	index, err := server.Storage.Set("test", TEST_DATA)
 	require.NoError(t, err)
@@ -880,7 +881,7 @@ func StorageObjectTest(server *Server, t *testing.T) {
 }
 
 // StorageListTest testing storage function
-func StorageListTest(server *Server, t *testing.T) {
+func StorageListTest(server *ooo.Server, t *testing.T) {
 	server.Storage.Clear()
 	key, err := server.Storage.Set("test/123", TEST_DATA)
 	require.NoError(t, err)
@@ -993,7 +994,7 @@ func StorageSetGetDelTestBenchmark(db storage.Database, b *testing.B) {
 }
 
 // StorageGetNTest testing storage GetN function
-func StorageGetNTest(server *Server, t *testing.T, n int) {
+func StorageGetNTest(server *ooo.Server, t *testing.T, n int) {
 	server.Storage.Clear()
 	for i := range n {
 		value := strconv.Itoa(i)
@@ -1029,7 +1030,7 @@ func StorageGetNTest(server *Server, t *testing.T, n int) {
 }
 
 // StorageGetNRangeTest testing storage GetN function
-func StorageGetNRangeTest(server *Server, t *testing.T, n int) {
+func StorageGetNRangeTest(server *ooo.Server, t *testing.T, n int) {
 	server.Storage.Clear()
 	for i := 1; i < n; i++ {
 		value := strconv.Itoa(i)
@@ -1051,7 +1052,7 @@ func StorageGetNRangeTest(server *Server, t *testing.T, n int) {
 }
 
 // StorageKeysRangeTest testing storage KeysRange function
-func StorageKeysRangeTest(server *Server, t *testing.T, n int) {
+func StorageKeysRangeTest(server *ooo.Server, t *testing.T, n int) {
 	server.Storage.Clear()
 	first := ""
 	firstNow := int64(0)
@@ -1228,7 +1229,7 @@ func WatchStorageNoopTest(db storage.Database, t *testing.T) {
 	db.Clear()
 }
 
-func StorageBatchSetTest(server *Server, t *testing.T, n int) {
+func StorageBatchSetTest(server *ooo.Server, t *testing.T, n int) {
 	server.Storage.Clear()
 	testData := json.RawMessage(`{"test":"123"}`)
 	for i := 1; i < n; i++ {

--- a/oootest/stream.go
+++ b/oootest/stream.go
@@ -1,4 +1,4 @@
-package ooo
+package oootest
 
 import (
 	"encoding/json"
@@ -13,6 +13,7 @@ import (
 
 	"github.com/benitogf/jsondiff"
 	"github.com/benitogf/jsonpatch"
+	"github.com/benitogf/ooo"
 	"github.com/benitogf/ooo/client"
 	ooio "github.com/benitogf/ooo/io"
 	"github.com/benitogf/ooo/messages"
@@ -24,7 +25,7 @@ import (
 )
 
 // remoteConfig creates a RemoteConfig for the given server
-func remoteConfig(server *Server) ooio.RemoteConfig {
+func remoteConfig(server *ooo.Server) ooio.RemoteConfig {
 	return ooio.RemoteConfig{
 		Client: &http.Client{},
 		Host:   server.Address,
@@ -33,7 +34,7 @@ func remoteConfig(server *Server) ooio.RemoteConfig {
 
 // StreamBroadcastTest testing stream function
 // Note: Uses raw websocket to verify patch protocol and meta.Object structure
-func StreamBroadcastTest(t *testing.T, server *Server) {
+func StreamBroadcastTest(t *testing.T, server *ooo.Server) {
 	var wg sync.WaitGroup
 	var postIndexResponse ooio.IndexResponse
 	var wsObject meta.Object
@@ -108,7 +109,7 @@ func StreamBroadcastTest(t *testing.T, server *Server) {
 
 // StreamItemGlobBroadcastTest testing stream function
 // Note: Uses raw websocket to verify patch protocol and meta.Object structure
-func StreamItemGlobBroadcastTest(t *testing.T, server *Server) {
+func StreamItemGlobBroadcastTest(t *testing.T, server *ooo.Server) {
 	var wg sync.WaitGroup
 	var postIndexResponse ooio.IndexResponse
 	var wsObject meta.Object
@@ -184,7 +185,7 @@ func StreamItemGlobBroadcastTest(t *testing.T, server *Server) {
 
 // StreamGlobBroadcastTest testing stream function
 // Note: This test uses raw websocket to verify patch/snapshot protocol behavior
-func StreamGlobBroadcastTest(t *testing.T, server *Server, n int) {
+func StreamGlobBroadcastTest(t *testing.T, server *ooo.Server, n int) {
 	var wg sync.WaitGroup
 	var indexResponse ooio.IndexResponse
 	var wsObjects []meta.Object
@@ -302,7 +303,7 @@ func StreamGlobBroadcastTest(t *testing.T, server *Server, n int) {
 
 // StreamBroadcastFilterTest testing stream function
 // Note: This test uses raw websocket to verify snapshot/patch protocol behavior
-func StreamBroadcastFilterTest(t *testing.T, server *Server) {
+func StreamBroadcastFilterTest(t *testing.T, server *ooo.Server) {
 	var wg sync.WaitGroup
 	var wsExtraEvent messages.Message
 	var callCount int
@@ -352,7 +353,7 @@ func StreamBroadcastFilterTest(t *testing.T, server *Server) {
 
 // StreamBroadcastForcePatchTest testing stream function
 // Note: This test uses raw websocket to verify ForcePatch behavior (no snapshots after first)
-func StreamBroadcastForcePatchTest(t *testing.T, server *Server) {
+func StreamBroadcastForcePatchTest(t *testing.T, server *ooo.Server) {
 	var wg sync.WaitGroup
 	var wsExtraEvent messages.Message
 	// extra route
@@ -412,7 +413,7 @@ func StreamBroadcastForcePatchTest(t *testing.T, server *Server) {
 
 // StreamBroadcastNoPatchTest testing stream function
 // Note: This test uses raw websocket to verify NoPatch behavior (all messages are snapshots)
-func StreamBroadcastNoPatchTest(t *testing.T, server *Server) {
+func StreamBroadcastNoPatchTest(t *testing.T, server *ooo.Server) {
 	var wg sync.WaitGroup
 	var wsExtraEvent messages.Message
 	// extra route
@@ -454,7 +455,7 @@ func StreamBroadcastNoPatchTest(t *testing.T, server *Server) {
 	wg.Wait()
 }
 
-func StreamGlobBroadcastConcurrentTest(t *testing.T, server *Server, n int) {
+func StreamGlobBroadcastConcurrentTest(t *testing.T, server *ooo.Server, n int) {
 	type TestData struct {
 		SearchMetadata struct {
 			Count float64 `json:"count"`
@@ -551,7 +552,7 @@ func StreamGlobBroadcastConcurrentTest(t *testing.T, server *Server, n int) {
 	entriesLock.Unlock()
 }
 
-func StreamBroadcastPatchTest(t *testing.T, server *Server) {
+func StreamBroadcastPatchTest(t *testing.T, server *ooo.Server) {
 	var wg sync.WaitGroup
 	type TestSubField struct {
 		One   string `json:"one"`
@@ -621,7 +622,7 @@ func StreamBroadcastPatchTest(t *testing.T, server *Server) {
 // when items are inserted and broadcast to subscribed clients.
 // The client should never see more than the limit number of items due to ReadListFilter.
 // Note: This test uses raw websocket to verify patch protocol and limit enforcement
-func StreamLimitFilterTest(t *testing.T, server *Server) {
+func StreamLimitFilterTest(t *testing.T, server *ooo.Server) {
 	var wg sync.WaitGroup
 	var wsObjects []meta.Object
 	var wsEvent messages.Message
@@ -631,7 +632,7 @@ func StreamLimitFilterTest(t *testing.T, server *Server) {
 	const totalInserts = limit + 5 // Insert more than the limit
 
 	// Set up limit filter - uses ReadListFilter to limit view + AfterWrite to cleanup
-	server.LimitFilter("limited/*", LimitFilterConfig{Limit: limit})
+	server.LimitFilter("limited/*", ooo.LimitFilterConfig{Limit: limit})
 	cfg := remoteConfig(server)
 
 	// Subscribe using raw websocket
@@ -701,7 +702,7 @@ func StreamLimitFilterTest(t *testing.T, server *Server) {
 // 3. Glob delete: multiple items deleted with single broadcast returning empty list
 // 4. List sort order: newest first (descending by created)
 // 5. Nested paths: box/*/things/* pattern matching
-func ClientCompatibilityTest(t *testing.T, server *Server) {
+func ClientCompatibilityTest(t *testing.T, server *ooo.Server) {
 	cfg := remoteConfig(server)
 
 	// Test 1: Object lifecycle - verify updated field behavior

--- a/rest_test.go
+++ b/rest_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/benitogf/go-json"
 	"github.com/benitogf/ooo"
 	"github.com/benitogf/ooo/meta"
+	"github.com/benitogf/ooo/oootest"
 	"github.com/benitogf/ooo/storage"
 	"github.com/stretchr/testify/require"
 )
@@ -191,7 +192,7 @@ func TestRestDel(t *testing.T) {
 	server.Start("localhost:0")
 	defer server.Close(os.Interrupt)
 	_ = server.Storage.Del("test")
-	index, err := server.Storage.Set("test", ooo.TEST_DATA)
+	index, err := server.Storage.Set("test", oootest.TEST_DATA)
 	require.NoError(t, err)
 	require.Equal(t, "test", index)
 
@@ -218,10 +219,10 @@ func TestRestDel(t *testing.T) {
 	resp = w.Result()
 	require.Equal(t, http.StatusNotFound, resp.StatusCode)
 
-	index, err = server.Storage.Set("test/1", ooo.TEST_DATA)
+	index, err = server.Storage.Set("test/1", oootest.TEST_DATA)
 	require.NoError(t, err)
 	require.Equal(t, "1", index)
-	index, err = server.Storage.Set("test/2", ooo.TEST_DATA_UPDATE)
+	index, err = server.Storage.Set("test/2", oootest.TEST_DATA_UPDATE)
 	require.NoError(t, err)
 	require.Equal(t, "2", index)
 
@@ -271,10 +272,10 @@ func TestRestGet(t *testing.T) {
 	server.Storage.Clear()
 	defer server.Close(os.Interrupt)
 	_ = server.Storage.Del("test")
-	index, err := server.Storage.Set("test", ooo.TEST_DATA)
+	index, err := server.Storage.Set("test", oootest.TEST_DATA)
 	require.NoError(t, err)
 	require.Equal(t, "test", index)
-	index, err = server.Storage.Set("sources", ooo.TEST_DATA_UPDATE)
+	index, err = server.Storage.Set("sources", oootest.TEST_DATA_UPDATE)
 	require.NoError(t, err)
 	require.Equal(t, "sources", index)
 	data, _ := server.Storage.Get("test")
@@ -318,7 +319,7 @@ func TestRestStats(t *testing.T) {
 	server.Start("localhost:0")
 	defer server.Close(os.Interrupt)
 
-	index, err := server.Storage.Set("test/1", ooo.TEST_DATA)
+	index, err := server.Storage.Set("test/1", oootest.TEST_DATA)
 	require.NoError(t, err)
 	require.NotEmpty(t, index)
 
@@ -356,11 +357,11 @@ func TestRestResponseCode(t *testing.T) {
 	server.Start("localhost:0")
 	defer server.Close(os.Interrupt)
 
-	index, err := server.Storage.Set("test", ooo.TEST_DATA)
+	index, err := server.Storage.Set("test", oootest.TEST_DATA)
 	require.NoError(t, err)
 	require.NotEmpty(t, index)
 
-	index, err = server.Storage.Set("test/1", ooo.TEST_DATA_UPDATE)
+	index, err = server.Storage.Set("test/1", oootest.TEST_DATA_UPDATE)
 	require.NoError(t, err)
 	require.NotEmpty(t, index)
 


### PR DESCRIPTION
## Summary
Re-lands the move of the shared test helpers to a sibling package so
production binaries built on ooo no longer carry the Go test framework
and no longer advertise `-test.*` flags in their `--help` output.
Same shape as the previously closed [PR #69](https://github.com/benitogf/ooo/pull/69),
with a coordinated downstream follow-up.

## Verification
- `go list -deps github.com/benitogf/ooo` no longer contains
  `testing`, `testing/quick`, `net/http/httptest`, or any
  `github.com/stretchr/testify/*` package. Before this change the
  same query listed all four.
- Full race-clean suite green: `go test -race ./...` across every
  package in the module.
- `--help` output of a service built on the resulting binary no
  longer surfaces `-test.bench`, `-test.run`, etc.

## Downstream follow-up
The downstream consumer's production code is **unaffected** — only its
test files reference the moved helpers. A separate PR on
[ko](https://github.com/benitogf/ko) will bump its `go.mod` to the
merged SHA and switch its test imports to the new sibling package.

Closes #128.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)