### PR TITLE
refactor(server): one phased RegisterCloseHook API for teardown

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,19 +488,21 @@ The orchestrator should send SIGTERM first and grant a grace window at least as 
 
 On Kubernetes, set `terminationGracePeriodSeconds` accordingly. The default of 30s is enough for most configurations; raise it if you've increased `Server.Deadline` or if your callbacks flush sizable state.
 
-### Teardown callbacks
+### Teardown hooks
 
-`Server` exposes three places to register teardown code, each running at a different point in `Close`:
+`Server.RegisterCloseHook(phase, fn)` registers teardown code to run at one of three points in `Close`. Multiple hooks at the same phase run in registration order; phases themselves run in declaration order.
 
-| Hook | When it runs | Storage / stream / HTTP state | Typical use |
+| Phase | When it runs | Storage / stream / HTTP state | Typical use |
 |---|---|---|---|
-| `RegisterPreClose(fn)` | First, before any tear-down | All up | Flush in-memory state to storage, broadcast a "shutting down" message |
-| `RegisterProxyCleanup(fn)` | After preClose, before the stream closes | Stream still up | Unsubscribe from upstream proxy servers |
-| `OnClose` (field) | Last, after everything else is closed | All torn down | Close user-owned resources (DB pools, log handles) |
+| `ooo.PreShutdown` | First, before any tear-down | All up | Flush in-memory state to storage, broadcast a "shutting down" message |
+| `ooo.ProxyTeardown` | After PreShutdown, before the stream closes | Stream still up | Unsubscribe from upstream proxy servers |
+| `ooo.PostShutdown` | Last, after everything else is closed | All torn down | Close user-owned resources (DB pools, log handles) |
 
-Callbacks run synchronously and `Close` blocks until each returns. By default there is **no aggregate timeout** on user callbacks — a callback that hangs hangs `Close`, which can push the orchestrator past `terminationGracePeriodSeconds` and trigger SIGKILL. Keep callbacks short, or make them respect their own timeouts.
+The earlier per-phase registrars (`RegisterPreClose`, `RegisterProxyCleanup`, and the `OnClose` field) remain available as deprecated thin shims over `RegisterCloseHook`, so existing code keeps working unchanged. New code should prefer the phased API.
 
-To opt into a hard bound on the combined runtime of `preClose`, `proxy`, and `OnClose` callbacks, set `Server.CloseCallbackBudget` to a positive `time.Duration`. Only the time spent inside callbacks counts toward this budget — the wall clock that `Close` spends in its own internal teardown (the `Deadline`-bounded HTTP drain, `Storage.Close`, waitgroup joins) is not charged against it, so a slow drain will not silently consume the budget that callbacks were meant to use. Once the cumulative callback-runtime exceeds the budget, remaining callbacks are skipped and a one-line warning is logged via `Server.Console`. A callback that is already running is not interrupted — Go cannot cancel arbitrary user code — only callbacks that have not yet started are skipped. The default (zero) preserves the existing unbounded contract.
+Hooks run synchronously and `Close` blocks until each returns. By default there is **no aggregate timeout** on user callbacks — a callback that hangs hangs `Close`, which can push the orchestrator past `terminationGracePeriodSeconds` and trigger SIGKILL. Keep callbacks short, or make them respect their own timeouts.
+
+To opt into a hard bound on the combined runtime of every registered hook, set `Server.CloseCallbackBudget` to a positive `time.Duration`. Only the time spent inside hooks counts toward this budget — the wall clock that `Close` spends in its own internal teardown (the `Deadline`-bounded HTTP drain, `Storage.Close`, waitgroup joins) is not charged against it, so a slow drain will not silently consume the budget that callbacks were meant to use. Once the cumulative callback-runtime exceeds the budget, remaining callbacks are skipped and a one-line warning is logged via `Server.Console`. A callback that is already running is not interrupted — Go cannot cancel arbitrary user code — only callbacks that have not yet started are skipped. The default (zero) preserves the existing unbounded contract.
 
 ### Custom Endpoint handlers
 

--- a/endpoint.go
+++ b/endpoint.go
@@ -247,22 +247,37 @@ func (server *Server) RegisterProxy(info ui.ProxyInfo) {
 	server.registryMu.Unlock()
 }
 
+// RegisterCloseHook registers fn to run during Server.Close at the
+// given teardown phase. Multiple hooks at the same phase run in
+// registration order. Phases run in CloseHookPhase declaration order
+// (PreShutdown → ProxyTeardown → PostShutdown). The aggregate
+// callback runtime is bounded by Server.CloseCallbackBudget when set.
+// Panics if phase is out of range.
+func (server *Server) RegisterCloseHook(phase CloseHookPhase, fn func()) {
+	if phase < PreShutdown || phase >= closeHookPhaseCount {
+		panic("ooo: RegisterCloseHook called with invalid CloseHookPhase")
+	}
+	server.closeHooksMu.Lock()
+	server.closeHooks[phase] = append(server.closeHooks[phase], fn)
+	server.closeHooksMu.Unlock()
+}
+
 // RegisterProxyCleanup registers a cleanup function to be called when the server closes.
 // This is used by proxy routes to clean up their remote subscriptions.
+//
+// Deprecated: use RegisterCloseHook(ProxyTeardown, cleanup) instead.
 func (server *Server) RegisterProxyCleanup(cleanup func()) {
-	server.proxyCleanupMu.Lock()
-	server.proxyCleanups = append(server.proxyCleanups, cleanup)
-	server.proxyCleanupMu.Unlock()
+	server.RegisterCloseHook(ProxyTeardown, cleanup)
 }
 
 // RegisterPreClose registers a cleanup function to be called at the very start of Close(),
 // before stream and storage cleanup. This is useful for stopping background goroutines
 // that depend on the stream being active. Multiple functions can be registered and will
 // be called in registration order.
+//
+// Deprecated: use RegisterCloseHook(PreShutdown, cleanup) instead.
 func (server *Server) RegisterPreClose(cleanup func()) {
-	server.preCloseCleanupsMu.Lock()
-	server.preCloseCleanups = append(server.preCloseCleanups, cleanup)
-	server.preCloseCleanupsMu.Unlock()
+	server.RegisterCloseHook(PreShutdown, cleanup)
 }
 
 // getEndpoints returns a snapshot of the registered endpoints. Takes

--- a/filters.go
+++ b/filters.go
@@ -163,9 +163,7 @@ func (server *Server) registerLimitFilter(path string, lf *filters.LimitFilter, 
 	lf.StartCleanup()
 
 	// Register stop on server close
-	server.preCloseCleanupsMu.Lock()
-	server.preCloseCleanups = append(server.preCloseCleanups, lf.StopCleanup)
-	server.preCloseCleanupsMu.Unlock()
+	server.RegisterCloseHook(PreShutdown, lf.StopCleanup)
 
 	// Register for explorer display
 	server.RegisterLimitFilter(lf, description, schema)

--- a/ooo.go
+++ b/ooo.go
@@ -114,6 +114,30 @@ const DefaultMaxRequestBodyBytes = 10 * 1024 * 1024 // 10 MiB
 // false: rejects the request
 type audit func(r *http.Request) bool
 
+// CloseHookPhase identifies when a teardown hook runs during Server.Close.
+// Phases run in declaration order; multiple hooks at the same phase run
+// in registration order. See RegisterCloseHook.
+type CloseHookPhase int
+
+const (
+	// PreShutdown runs first, before any internal teardown. Storage,
+	// stream, and HTTP are still up — hooks may broadcast, read, or
+	// write. Use this to flush in-memory state or notify subscribers
+	// that the server is shutting down.
+	PreShutdown CloseHookPhase = iota
+	// ProxyTeardown runs after PreShutdown but before stream
+	// connections are closed. Use this to unsubscribe from upstream
+	// proxy servers while the stream layer is still available.
+	ProxyTeardown
+	// PostShutdown runs last, after every internal teardown step.
+	// Storage, stream, and HTTP are all torn down — use this for
+	// closing user-owned resources (DB pools, log handles). The
+	// deprecated Server.OnClose field, if set, runs after every
+	// PostShutdown hook.
+	PostShutdown
+	closeHookPhaseCount
+)
+
 // Server is the main application struct for the ooo server.
 //
 // Name: display name for the server, shown in the storage explorer title
@@ -208,25 +232,28 @@ type Server struct {
 	// waitListen takes RLock around Match, then dispatches the
 	// matched handler without the lock so long-running handlers do
 	// not block subsequent registrations.
-	routerMu           sync.RWMutex
-	routeOracle        *mux.Router  // mirrors Endpoint/Proxy paths so the data wildcard can defer to them
-	routeOracleMu      sync.RWMutex // protects routeOracle; readers (routeOracleSkip) take RLock on the data-wildcard hot path, registrations take Lock
-	proxyCleanups      []func()     // cleanup functions for proxy subscriptions
-	proxyCleanupMu     sync.Mutex   // protects proxyCleanups
-	NoBroadcastKeys    []string
-	Audit              audit
-	Workers            int
-	ForcePatch         bool
-	NoPatch            bool
-	OnSubscribe        stream.Subscribe
-	OnUnsubscribe      stream.Unsubscribe
-	OnStart            func()
-	OnClose            func()
-	preCloseCleanups   []func() // cleanup functions called before stream/storage close
-	preCloseCleanupsMu sync.Mutex
+	routerMu        sync.RWMutex
+	routeOracle     *mux.Router                   // mirrors Endpoint/Proxy paths so the data wildcard can defer to them
+	routeOracleMu   sync.RWMutex                  // protects routeOracle; readers (routeOracleSkip) take RLock on the data-wildcard hot path, registrations take Lock
+	closeHooks      [closeHookPhaseCount][]func() // teardown hooks indexed by CloseHookPhase
+	closeHooksMu    sync.Mutex                    // protects closeHooks
+	NoBroadcastKeys []string
+	Audit           audit
+	Workers         int
+	ForcePatch      bool
+	NoPatch         bool
+	OnSubscribe     stream.Subscribe
+	OnUnsubscribe   stream.Unsubscribe
+	OnStart         func()
+	// OnClose runs as the final teardown step, after every PostShutdown
+	// hook. Deprecated: use RegisterCloseHook(PostShutdown, fn) instead;
+	// the field is kept for backwards compatibility and runs last so
+	// existing callers see no behaviour change.
+	OnClose func()
 	// CloseCallbackBudget caps the aggregate runtime of user-supplied
-	// teardown callbacks (RegisterPreClose, RegisterProxyCleanup, and
-	// OnClose) during Close. Only the time spent INSIDE callbacks
+	// teardown hooks registered via RegisterCloseHook (and the
+	// deprecated RegisterPreClose / RegisterProxyCleanup / OnClose
+	// surface) during Close. Only the time spent INSIDE hooks
 	// counts against this budget — the wall clock spent in ooo's own
 	// internal teardown (Deadline-bounded HTTP drain, Storage.Close,
 	// waitgroup joins) is not charged. A callback already running is
@@ -925,12 +952,14 @@ func (server *Server) Start(address string) {
 //
 //  1. Mark the server as closing (atomic, idempotent — second concurrent
 //     call returns immediately).
-//  2. Run preClose cleanups (registered via Server.RegisterPreClose).
-//     Storage, stream, and HTTP are still up — callbacks may broadcast,
-//     read, or write.
+//  2. Run PreShutdown hooks (registered via RegisterCloseHook;
+//     RegisterPreClose is the deprecated equivalent). Storage,
+//     stream, and HTTP are still up — hooks may broadcast, read, or
+//     write.
 //  3. Stop the internal clock goroutine (bounded — clock selects on a
 //     stop channel).
-//  4. Run proxy cleanups (registered via Server.RegisterProxyCleanup).
+//  4. Run ProxyTeardown hooks (registered via RegisterCloseHook;
+//     RegisterProxyCleanup is the deprecated equivalent).
 //  5. Close all WebSocket connections (bounded — per-connection TCP close).
 //  6. Stop the HTTP server: graceful shutdown with a context bounded by
 //     Server.Deadline (default 10s), then force-close to cancel any
@@ -941,8 +970,9 @@ func (server *Server) Start(address string) {
 //  8. Close the storage backend.
 //  9. Wait for storage-watcher goroutines (bounded — they exit when
 //     storage closes their channels).
-//  10. Run Server.OnClose. Storage, stream, and HTTP are all torn down —
-//     use this for closing user-owned resources only.
+//  10. Run PostShutdown hooks, then the deprecated Server.OnClose
+//     field if set. Storage, stream, and HTTP are all torn down — use
+//     these for closing user-owned resources only.
 //
 // Bound:
 //
@@ -999,9 +1029,13 @@ func (server *Server) Close(sig os.Signal) {
 			cb()
 			callbackElapsed += time.Since(start)
 		}
-		runCallbacks := func(name string, callbacks []func()) {
+		runPhase := func(phase CloseHookPhase, name string) {
+			server.closeHooksMu.Lock()
+			hooks := server.closeHooks[phase]
+			server.closeHooks[phase] = nil
+			server.closeHooksMu.Unlock()
 			var skipped int
-			for _, cb := range callbacks {
+			for _, cb := range hooks {
 				if budgetExceeded() {
 					skipped++
 					continue
@@ -1009,21 +1043,16 @@ func (server *Server) Close(sig os.Signal) {
 				runOne(cb)
 			}
 			if skipped > 0 {
-				server.Console.Err("close: skipped", skipped, name, "callback(s); CloseCallbackBudget exceeded")
+				server.Console.Err("close: skipped", skipped, name, "hook(s); CloseCallbackBudget exceeded")
 			}
 		}
-		// Call pre-close cleanups first, before any stream/storage cleanup
-		server.preCloseCleanupsMu.Lock()
-		runCallbacks("preClose", server.preCloseCleanups)
-		server.preCloseCleanups = nil
-		server.preCloseCleanupsMu.Unlock()
+		// PreShutdown hooks run first, before any stream/storage cleanup.
+		runPhase(PreShutdown, "PreShutdown")
 		close(server.clockStop) // Signal clock goroutine to stop immediately
 		server.clockWg.Wait()   // Wait for clock goroutine to exit before touching Stream
-		// Close proxy subscriptions first (before closing stream connections)
-		server.proxyCleanupMu.Lock()
-		runCallbacks("proxyCleanup", server.proxyCleanups)
-		server.proxyCleanups = nil
-		server.proxyCleanupMu.Unlock()
+		// ProxyTeardown hooks run before stream connections are closed
+		// so proxy subscriptions can unsubscribe cleanly.
+		runPhase(ProxyTeardown, "ProxyTeardown")
 		// Force close all stream connections first
 		server.Stream.CloseAll()
 		// Shutdown HTTP server to stop accepting new connections. Bound the
@@ -1045,6 +1074,11 @@ func (server *Server) Close(sig os.Signal) {
 		server.listenWg.Wait()  // Wait for listen goroutine to finish
 		server.Storage.Close()
 		server.watchWg.Wait() // Wait for watch goroutines to finish
+		// PostShutdown hooks run after every internal teardown step;
+		// they see storage, stream, and HTTP all torn down.
+		runPhase(PostShutdown, "PostShutdown")
+		// OnClose field is the legacy single-shot PostShutdown hook;
+		// it runs after every registered PostShutdown hook.
 		if budgetExceeded() {
 			server.Console.Err("close: skipped OnClose callback; CloseCallbackBudget exceeded")
 		} else {

--- a/ooo_test.go
+++ b/ooo_test.go
@@ -914,3 +914,83 @@ func TestCloseCallbackBudgetZeroPreservesUnboundedContract(t *testing.T) {
 	require.Equal(t, int64(4), ran.Load(),
 		"with no budget set, all four callbacks should run unconditionally")
 }
+
+// TestRegisterCloseHookOrdering asserts that hooks registered via the
+// new phased API run in phase order (PreShutdown → ProxyTeardown →
+// PostShutdown) and, within a phase, in registration order.
+func TestRegisterCloseHookOrdering(t *testing.T) {
+	var ordered []string
+	var mu sync.Mutex
+	record := func(label string) func() {
+		return func() {
+			mu.Lock()
+			ordered = append(ordered, label)
+			mu.Unlock()
+		}
+	}
+
+	server := &Server{Silence: true}
+	server.Start("localhost:0")
+
+	// Register out of phase order to prove the phase tag, not registration
+	// order, drives execution order across phases.
+	server.RegisterCloseHook(PostShutdown, record("post-1"))
+	server.RegisterCloseHook(PreShutdown, record("pre-1"))
+	server.RegisterCloseHook(ProxyTeardown, record("proxy-1"))
+	server.RegisterCloseHook(PreShutdown, record("pre-2"))
+	server.RegisterCloseHook(PostShutdown, record("post-2"))
+
+	server.Close(os.Interrupt)
+
+	require.Equal(t,
+		[]string{"pre-1", "pre-2", "proxy-1", "post-1", "post-2"},
+		ordered,
+	)
+}
+
+// TestRegisterCloseHookOldAPIsDelegateToPhases asserts that the
+// deprecated RegisterPreClose / RegisterProxyCleanup / OnClose surface
+// behaves as if it had been registered via RegisterCloseHook at the
+// corresponding phase. Mixed registration across old + new APIs still
+// produces a deterministic, phase-ordered sequence.
+func TestRegisterCloseHookOldAPIsDelegateToPhases(t *testing.T) {
+	var ordered []string
+	var mu sync.Mutex
+	record := func(label string) func() {
+		return func() {
+			mu.Lock()
+			ordered = append(ordered, label)
+			mu.Unlock()
+		}
+	}
+
+	server := &Server{Silence: true}
+	server.Start("localhost:0")
+
+	server.RegisterPreClose(record("legacy-pre"))
+	server.RegisterCloseHook(PreShutdown, record("new-pre"))
+	server.RegisterProxyCleanup(record("legacy-proxy"))
+	server.RegisterCloseHook(ProxyTeardown, record("new-proxy"))
+	server.RegisterCloseHook(PostShutdown, record("new-post"))
+	server.OnClose = record("legacy-onclose")
+
+	server.Close(os.Interrupt)
+
+	require.Equal(t,
+		[]string{"legacy-pre", "new-pre", "legacy-proxy", "new-proxy", "new-post", "legacy-onclose"},
+		ordered,
+	)
+}
+
+// TestRegisterCloseHookInvalidPhasePanics asserts that registering a
+// hook with an out-of-range phase value panics immediately (caller
+// bug), rather than silently dropping the hook at Close time.
+func TestRegisterCloseHookInvalidPhasePanics(t *testing.T) {
+	server := &Server{Silence: true}
+	require.Panics(t, func() {
+		server.RegisterCloseHook(CloseHookPhase(99), func() {})
+	})
+	require.Panics(t, func() {
+		server.RegisterCloseHook(CloseHookPhase(-1), func() {})
+	})
+}


### PR DESCRIPTION
## Summary
Replaces three separate teardown registration surfaces with one
phased API. `Server.RegisterCloseHook(phase, fn)` registers a hook
to run at the named `CloseHookPhase` (`PreShutdown`,
`ProxyTeardown`, `PostShutdown`) during `Close`. The earlier
registrars (`RegisterPreClose`, `RegisterProxyCleanup`, and the
`OnClose` field) remain as deprecated thin shims so no consumer
source change is required.

## Verification
- New `TestRegisterCloseHookOrdering`: registers five hooks across
  the three phases in deliberately scrambled order and asserts
  execution order is phase-by-phase, then registration-order
  within a phase.
- New `TestRegisterCloseHookOldAPIsDelegateToPhases`: mixes the
  old `RegisterPreClose` / `RegisterProxyCleanup` / `OnClose`
  surface with the new `RegisterCloseHook` calls and asserts the
  combined sequence is exactly phase-order with old + new entries
  interleaved by registration order.
- New `TestRegisterCloseHookInvalidPhasePanics`: asserts an
  out-of-range `CloseHookPhase` panics at registration, not at
  `Close` time.
- The existing `TestCloseCallbackBudget*` tests continue to pass —
  the budget machinery now applies uniformly across all three
  phases.
- Race-clean across the module: `go test -race -timeout 180s ./...`
  green.

## Notes
- `OnClose` (the field) is documented as deprecated but kept
  functional. It runs after every `PostShutdown` hook so its
  historical "last call" guarantee is preserved.
- Internally the two old slice + mutex pairs collapse into one
  `closeHooks [3][]func()` and one mutex, so there is less locking
  and one fewer registration code path to keep in sync.
- `filters.go` no longer touches the old internal field; it uses
  the public method like everyone else.

Closes #132.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)