### PR TITLE
refactor: deduplicate reflectSchema helpers into shared schema package

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -3,10 +3,9 @@ package ooo
 import (
 	"fmt"
 	"net/http"
-	"reflect"
 	"regexp"
-	"strings"
 
+	"github.com/benitogf/ooo/schema"
 	"github.com/benitogf/ooo/ui"
 )
 
@@ -57,121 +56,6 @@ func extractPathVars(path string) Vars {
 	return vars
 }
 
-// reflectSchema generates a schema from a Go type using reflection
-func reflectSchema(t any) map[string]any {
-	if t == nil {
-		return nil
-	}
-
-	rv := reflect.ValueOf(t)
-	rt := rv.Type()
-
-	// Handle pointer types
-	if rt.Kind() == reflect.Ptr {
-		rt = rt.Elem()
-		rv = reflect.New(rt).Elem()
-	}
-
-	if rt.Kind() != reflect.Struct {
-		return map[string]any{"type": rt.Kind().String()}
-	}
-
-	schema := make(map[string]any)
-	for i := 0; i < rt.NumField(); i++ {
-		field := rt.Field(i)
-
-		// Skip unexported fields
-		if !field.IsExported() {
-			continue
-		}
-
-		// Get JSON tag name
-		jsonTag := field.Tag.Get("json")
-		if jsonTag == "-" {
-			continue
-		}
-
-		parts := strings.Split(jsonTag, ",")
-		fieldName := field.Name
-		if parts[0] != "" {
-			fieldName = parts[0]
-		}
-
-		// Skip omitempty fields in request schema - they're optional
-		hasOmitempty := false
-		for _, opt := range parts[1:] {
-			if opt == "omitempty" {
-				hasOmitempty = true
-				break
-			}
-		}
-		if hasOmitempty {
-			continue
-		}
-
-		// Generate default value based on type
-		schema[fieldName] = defaultValue(field.Type)
-	}
-
-	return schema
-}
-
-// defaultValue returns a default value for a type
-func defaultValue(t reflect.Type) any {
-	switch t.Kind() {
-	case reflect.String:
-		return ""
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return 0
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		return 0
-	case reflect.Float32, reflect.Float64:
-		return 0.0
-	case reflect.Bool:
-		return false
-	case reflect.Slice:
-		elemDefault := defaultValue(t.Elem())
-		return []any{elemDefault}
-	case reflect.Map:
-		return map[string]any{}
-	case reflect.Struct:
-		// Recursively handle nested structs
-		nested := make(map[string]any)
-		for i := 0; i < t.NumField(); i++ {
-			field := t.Field(i)
-			if !field.IsExported() {
-				continue
-			}
-			jsonTag := field.Tag.Get("json")
-			if jsonTag == "-" {
-				continue
-			}
-			parts := strings.Split(jsonTag, ",")
-			fieldName := field.Name
-			if parts[0] != "" {
-				fieldName = parts[0]
-			}
-			// Skip omitempty fields
-			hasOmitempty := false
-			for _, opt := range parts[1:] {
-				if opt == "omitempty" {
-					hasOmitempty = true
-					break
-				}
-			}
-			if hasOmitempty {
-				continue
-			}
-			nested[fieldName] = defaultValue(field.Type)
-		}
-		return nested
-	case reflect.Ptr:
-		return defaultValue(t.Elem())
-	default:
-		return nil
-	}
-}
-
 // AuditHandler wraps next so the configured Server.Audit gate runs
 // before the handler. Returns 401 Unauthorized when Audit denies the
 // request. Used by Endpoint registration and the proxy package so
@@ -202,8 +86,8 @@ func (server *Server) Endpoint(cfg EndpointConfig) {
 
 		info := ui.MethodInfo{
 			Method:   method,
-			Request:  reflectSchema(spec.Request),
-			Response: reflectSchema(spec.Response),
+			Request:  schema.Reflect(spec.Request),
+			Response: schema.Reflect(spec.Response),
 			Params:   spec.Params,
 		}
 

--- a/filters.go
+++ b/filters.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/benitogf/ooo/filters"
 	"github.com/benitogf/ooo/key"
+	"github.com/benitogf/ooo/schema"
 	"github.com/benitogf/ooo/ui"
 )
 
@@ -134,7 +135,7 @@ func (server *Server) LimitFilter(path string, cfg filters.LimitFilterConfig) {
 	if err != nil {
 		panic(err)
 	}
-	server.registerLimitFilter(path, lf, cfg.Description, reflectSchema(cfg.Schema))
+	server.registerLimitFilter(path, lf, cfg.Description, schema.Reflect(cfg.Schema))
 }
 
 func (server *Server) registerLimitFilter(path string, lf *filters.LimitFilter, description string, schema map[string]any) {

--- a/filters/filters.go
+++ b/filters/filters.go
@@ -2,129 +2,13 @@ package filters
 
 import (
 	"fmt"
-	"reflect"
-	"strings"
 
 	"github.com/benitogf/go-json"
 
 	"github.com/benitogf/ooo/key"
 	"github.com/benitogf/ooo/meta"
+	"github.com/benitogf/ooo/schema"
 )
-
-// reflectSchema generates a schema from a Go type using reflection
-func reflectSchema(t any) map[string]any {
-	if t == nil {
-		return nil
-	}
-
-	rv := reflect.ValueOf(t)
-	rt := rv.Type()
-
-	// Handle pointer types
-	if rt.Kind() == reflect.Ptr {
-		rt = rt.Elem()
-		rv = reflect.New(rt).Elem()
-	}
-
-	if rt.Kind() != reflect.Struct {
-		return map[string]any{"type": rt.Kind().String()}
-	}
-
-	schema := make(map[string]any)
-	for i := 0; i < rt.NumField(); i++ {
-		field := rt.Field(i)
-
-		// Skip unexported fields
-		if !field.IsExported() {
-			continue
-		}
-
-		// Get JSON tag name
-		jsonTag := field.Tag.Get("json")
-		if jsonTag == "-" {
-			continue
-		}
-
-		parts := strings.Split(jsonTag, ",")
-		fieldName := field.Name
-		if parts[0] != "" {
-			fieldName = parts[0]
-		}
-
-		// Skip omitempty fields in request schema - they're optional
-		hasOmitempty := false
-		for _, opt := range parts[1:] {
-			if opt == "omitempty" {
-				hasOmitempty = true
-				break
-			}
-		}
-		if hasOmitempty {
-			continue
-		}
-
-		// Generate default value based on type
-		schema[fieldName] = defaultValue(field.Type)
-	}
-
-	return schema
-}
-
-// defaultValue returns a default value for a type
-func defaultValue(t reflect.Type) any {
-	switch t.Kind() {
-	case reflect.String:
-		return ""
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return 0
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		return 0
-	case reflect.Float32, reflect.Float64:
-		return 0.0
-	case reflect.Bool:
-		return false
-	case reflect.Slice:
-		elemDefault := defaultValue(t.Elem())
-		return []any{elemDefault}
-	case reflect.Map:
-		return map[string]any{}
-	case reflect.Struct:
-		// Recursively handle nested structs
-		nested := make(map[string]any)
-		for i := 0; i < t.NumField(); i++ {
-			field := t.Field(i)
-			if !field.IsExported() {
-				continue
-			}
-			jsonTag := field.Tag.Get("json")
-			if jsonTag == "-" {
-				continue
-			}
-			parts := strings.Split(jsonTag, ",")
-			fieldName := field.Name
-			if parts[0] != "" {
-				fieldName = parts[0]
-			}
-			// Skip omitempty fields
-			hasOmitempty := false
-			for _, opt := range parts[1:] {
-				if opt == "omitempty" {
-					hasOmitempty = true
-					break
-				}
-			}
-			if hasOmitempty {
-				continue
-			}
-			nested[fieldName] = defaultValue(field.Type)
-		}
-		return nested
-	case reflect.Ptr:
-		return defaultValue(t.Elem())
-	default:
-		return nil
-	}
-}
 
 var (
 	ErrRouteNotDefined     = fmt.Errorf("filters: route not defined")
@@ -580,7 +464,7 @@ func (f *Filters) PathsInfo(limitFilters map[string]LimitFilterInfo) []FilterInf
 			pathInfo[filter.path].DescWrite = filter.description
 		}
 		if filter.schema != nil && pathInfo[filter.path].Schema == nil {
-			pathInfo[filter.path].Schema = reflectSchema(filter.schema)
+			pathInfo[filter.path].Schema = schema.Reflect(filter.schema)
 		}
 	}
 
@@ -594,7 +478,7 @@ func (f *Filters) PathsInfo(limitFilters map[string]LimitFilterInfo) []FilterInf
 			pathInfo[filter.path].DescRead = filter.description
 		}
 		if filter.schema != nil && pathInfo[filter.path].Schema == nil {
-			pathInfo[filter.path].Schema = reflectSchema(filter.schema)
+			pathInfo[filter.path].Schema = schema.Reflect(filter.schema)
 		}
 	}
 
@@ -608,7 +492,7 @@ func (f *Filters) PathsInfo(limitFilters map[string]LimitFilterInfo) []FilterInf
 			pathInfo[filter.path].DescRead = filter.description
 		}
 		if filter.schema != nil && pathInfo[filter.path].Schema == nil {
-			pathInfo[filter.path].Schema = reflectSchema(filter.schema)
+			pathInfo[filter.path].Schema = schema.Reflect(filter.schema)
 		}
 	}
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1,0 +1,135 @@
+// Package schema generates JSON-shaped schemas and default-value
+// skeletons from Go types via reflection. It serves the explorer UI
+// (endpoint request/response previews, limit-filter schemas) and
+// expects the same json struct-tag conventions used by encoding/json.
+package schema
+
+import (
+	"reflect"
+	"strings"
+)
+
+// Reflect generates a schema map from a Go type using reflection.
+// Non-struct types return a single-entry map keyed by "type" carrying
+// the kind name. Struct types return a map keyed by json-tag field
+// name (falling back to the Go field name), with each value populated
+// by DefaultValue. Unexported fields, fields tagged "-", and fields
+// tagged with "omitempty" are skipped. Pointers are dereferenced; nil
+// input returns nil.
+func Reflect(t any) map[string]any {
+	if t == nil {
+		return nil
+	}
+
+	rv := reflect.ValueOf(t)
+	rt := rv.Type()
+
+	// Handle pointer types
+	if rt.Kind() == reflect.Ptr {
+		rt = rt.Elem()
+		rv = reflect.New(rt).Elem()
+	}
+
+	if rt.Kind() != reflect.Struct {
+		return map[string]any{"type": rt.Kind().String()}
+	}
+
+	schema := make(map[string]any)
+	for i := 0; i < rt.NumField(); i++ {
+		field := rt.Field(i)
+
+		// Skip unexported fields
+		if !field.IsExported() {
+			continue
+		}
+
+		// Get JSON tag name
+		jsonTag := field.Tag.Get("json")
+		if jsonTag == "-" {
+			continue
+		}
+
+		parts := strings.Split(jsonTag, ",")
+		fieldName := field.Name
+		if parts[0] != "" {
+			fieldName = parts[0]
+		}
+
+		// Skip omitempty fields in request schema - they're optional
+		hasOmitempty := false
+		for _, opt := range parts[1:] {
+			if opt == "omitempty" {
+				hasOmitempty = true
+				break
+			}
+		}
+		if hasOmitempty {
+			continue
+		}
+
+		// Generate default value based on type
+		schema[fieldName] = DefaultValue(field.Type)
+	}
+
+	return schema
+}
+
+// DefaultValue returns a zero-shaped default for a reflect.Type
+// suitable for previewing a JSON payload of that shape. Slices return
+// a one-element array of the element's default so the UI shows the
+// nested shape. Structs recurse with the same json-tag rules as
+// Reflect. Pointers are dereferenced.
+func DefaultValue(t reflect.Type) any {
+	switch t.Kind() {
+	case reflect.String:
+		return ""
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return 0
+	case reflect.Float32, reflect.Float64:
+		return 0.0
+	case reflect.Bool:
+		return false
+	case reflect.Slice:
+		elemDefault := DefaultValue(t.Elem())
+		return []any{elemDefault}
+	case reflect.Map:
+		return map[string]any{}
+	case reflect.Struct:
+		// Recursively handle nested structs
+		nested := make(map[string]any)
+		for i := 0; i < t.NumField(); i++ {
+			field := t.Field(i)
+			if !field.IsExported() {
+				continue
+			}
+			jsonTag := field.Tag.Get("json")
+			if jsonTag == "-" {
+				continue
+			}
+			parts := strings.Split(jsonTag, ",")
+			fieldName := field.Name
+			if parts[0] != "" {
+				fieldName = parts[0]
+			}
+			// Skip omitempty fields
+			hasOmitempty := false
+			for _, opt := range parts[1:] {
+				if opt == "omitempty" {
+					hasOmitempty = true
+					break
+				}
+			}
+			if hasOmitempty {
+				continue
+			}
+			nested[fieldName] = DefaultValue(field.Type)
+		}
+		return nested
+	case reflect.Ptr:
+		return DefaultValue(t.Elem())
+	default:
+		return nil
+	}
+}

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -1,0 +1,60 @@
+package schema_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/benitogf/ooo/schema"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReflectNilReturnsNil(t *testing.T) {
+	require.Nil(t, schema.Reflect(nil))
+}
+
+func TestReflectNonStructReturnsKindOnly(t *testing.T) {
+	out := schema.Reflect("hello")
+	require.Equal(t, map[string]any{"type": "string"}, out)
+}
+
+func TestReflectStructUsesJSONTagsAndSkipsOmitempty(t *testing.T) {
+	type inner struct {
+		Name string `json:"name"`
+	}
+	type payload struct {
+		ID       int    `json:"id"`
+		Skip     string `json:"-"`
+		Optional string `json:"optional,omitempty"`
+		Nested   inner  `json:"nested"`
+		Tags     []int  `json:"tags"`
+		FreeForm map[string]any
+		// unexported is intentionally lowercase to verify it's skipped
+		unexported string
+	}
+	_ = payload{}.unexported // silence unused-field linter
+
+	got := schema.Reflect(payload{})
+	require.Equal(t, map[string]any{
+		"id":       0,
+		"nested":   map[string]any{"name": ""},
+		"tags":     []any{0},
+		"FreeForm": map[string]any{},
+	}, got)
+}
+
+func TestReflectPointerDereferences(t *testing.T) {
+	type body struct {
+		X bool `json:"x"`
+	}
+	got := schema.Reflect((*body)(nil))
+	require.Equal(t, map[string]any{"x": false}, got)
+}
+
+func TestDefaultValueCoversKinds(t *testing.T) {
+	require.Equal(t, "", schema.DefaultValue(reflect.TypeOf("")))
+	require.Equal(t, 0, schema.DefaultValue(reflect.TypeOf(int64(0))))
+	require.Equal(t, 0.0, schema.DefaultValue(reflect.TypeOf(float32(0))))
+	require.Equal(t, false, schema.DefaultValue(reflect.TypeOf(false)))
+	require.Equal(t, map[string]any{}, schema.DefaultValue(reflect.TypeOf(map[string]int{})))
+	require.Equal(t, []any{""}, schema.DefaultValue(reflect.TypeOf([]string{})))
+}


### PR DESCRIPTION
## Summary
Collapses two verbatim copies of the reflection-based schema helpers
into one shared `ooo/schema` package. Endpoint registration and
filter registration now both call into the same `schema.Reflect` /
`schema.DefaultValue`, so any future tweak to the shape (omitempty
handling, slice preview, struct recursion) lands in one place
instead of silently diverging across two surfaces.

## Verification
- New focused tests in `schema/schema_test.go` cover the contract:
  nil-in / nil-out, non-struct kind fallback, json-tag rules
  (skip unexported, skip `-`, skip `omitempty`, fall back to Go
  field name), pointer dereference, slice element preview, struct
  recursion.
- Race-clean across the module: `go test -race -timeout 180s ./...`
  green, including the existing endpoint and filter tests that
  exercise the call sites.
- gofmt clean.
- Diff stat: -240 duplicated lines removed, +195 new package
  (including ~60 lines of test coverage that didn't exist before).

## Notes
- Pure rename: the new exported functions are byte-equivalent to
  the previous unexported pair, so explorer-rendered schemas don't
  change. Behaviour preservation is the point of the refactor.
- No public API surface change outside the new package — none of
  the deleted helpers were exported.

Closes #134.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)