### PR TITLE
fix(filters): make LimitFilter.ReadListFilter input read-only

### DIFF
--- a/filters/limit.go
+++ b/filters/limit.go
@@ -3,6 +3,7 @@ package filters
 import (
 	"errors"
 	"log"
+	"slices"
 	"sort"
 	"sync"
 	"time"
@@ -190,11 +191,28 @@ func (lf *LimitFilter) ReadFilter(path string, data json.RawMessage) (json.RawMe
 	return json.Marshal(filtered)
 }
 
-// ReadListFilter returns a meta-based filter function that limits the list to the configured entries.
-// This is more efficient than ReadFilter as it avoids JSON encoding/decoding.
-// Applies time constraint first (filter by age), then count constraint (keep newest N),
-// then sorts for display based on Order setting.
+// ReadListFilter applies the configured time + count constraints to objs
+// and returns the resulting slice in the configured display order. It
+// applies the time constraint first (cheap, no sort), then truncates to
+// the count limit (sort + slice), then sorts for display.
+//
+// The input slice is treated as read-only: ReadListFilter writes into a
+// freshly-allocated slice and returns that, so the caller can keep
+// using objs unchanged afterwards. The internal Storage.GetList →
+// filter pipeline already passes fresh slices, but the method is
+// exported and directly callable, so the no-mutation contract is held
+// here rather than assumed at every call site.
+//
+// This is more efficient than ReadFilter as it avoids JSON
+// encoding/decoding.
 func (lf *LimitFilter) ReadListFilter(path string, objs []meta.Object) ([]meta.Object, error) {
+	// Defensive copy: callers keep ownership of their slice. slices.Clone
+	// preserves nil-vs-empty distinction so an empty input still
+	// serializes as `[]` (not `null`) when the result feeds the JSON
+	// broadcast. The clone is the only allocation this function makes
+	// beyond the eventual sort.Slice scratch; downstream consumers
+	// already JSON-encode the result, which dwarfs this cost.
+	objs = slices.Clone(objs)
 	// Step 1: Time constraint — filter by age (cheap comparison, no sort needed)
 	if lf.HasMaxAge() {
 		cutoff := lf.now() - lf.MaxAge().Nanoseconds()

--- a/filters/limit_test.go
+++ b/filters/limit_test.go
@@ -563,11 +563,7 @@ func TestLimitFilter_CountAndMaxAge_Composition(t *testing.T) {
 		return baseTime + 100*int64(time.Minute)
 	})
 
-	// Fresh copy since ReadListFilter modifies in-place
-	copy1 := make([]meta.Object, len(allItems))
-	copy(copy1, allItems)
-
-	filtered, err := lf.ReadListFilter("combo/*", copy1)
+	filtered, err := lf.ReadListFilter("combo/*", allItems)
 	require.NoError(t, err)
 	require.Len(t, filtered, 3, "time filter keeps 3, count allows 3")
 
@@ -580,10 +576,7 @@ func TestLimitFilter_CountAndMaxAge_Composition(t *testing.T) {
 		return baseTime + 50*int64(time.Minute)
 	})
 
-	copy2 := make([]meta.Object, len(allItems))
-	copy(copy2, allItems)
-
-	filtered, err = lf.ReadListFilter("combo/*", copy2)
+	filtered, err = lf.ReadListFilter("combo/*", allItems)
 	require.NoError(t, err)
 	require.Len(t, filtered, 3, "all survive time, count caps to 3 of 5")
 }
@@ -822,4 +815,36 @@ func TestLimitFilter_Accessors(t *testing.T) {
 	require.True(t, lf3.HasMaxAge())
 	require.True(t, lf3.IsDynamic())
 	require.Equal(t, time.Hour, lf3.MaxAge())
+}
+
+// TestReadListFilter_DoesNotMutateInput asserts that calling ReadListFilter
+// does not alter the caller's slice — neither its element order nor its
+// element values. The internal pipeline (Storage.GetList → filter chain)
+// happens to pass fresh slices today, but the function is exported and
+// directly callable; callers shouldn't have to know about an implicit
+// "we'll sort + truncate your slice" contract.
+func TestReadListFilter_DoesNotMutateInput(t *testing.T) {
+	server := ooo.Server{}
+	server.Silence = true
+	server.Start("localhost:0")
+	defer server.Close(os.Interrupt)
+
+	lf, err := filters.NewLimitFilter("items/*",
+		filters.LimitFilterConfig{Limit: 2, Order: filters.OrderDesc},
+		server.Storage,
+	)
+	require.NoError(t, err)
+
+	items := []meta.Object{
+		{Created: 10, Index: "a"},
+		{Created: 30, Index: "b"},
+		{Created: 20, Index: "c"},
+	}
+	snapshot := append([]meta.Object(nil), items...)
+
+	_, err = lf.ReadListFilter("items/*", items)
+	require.NoError(t, err)
+
+	require.Equal(t, snapshot, items,
+		"caller's slice must not be mutated by ReadListFilter")
 }


### PR DESCRIPTION
## Summary
Makes `LimitFilter.ReadListFilter` treat its input slice as
read-only. The previous implementation sorted and truncated in
place; the only call site that exists today (the
`Storage.GetList` → filter chain) hands it a fresh slice each
time, so nothing observably broke, but the trap was a silent
failure mode waiting for a new caller.

## Verification
- New `TestReadListFilter_DoesNotMutateInput` calls the helper
  with a 3-element slice that would be sorted + truncated, then
  asserts the caller's slice is byte-for-byte unchanged. Failed
  before the fix; passes after.
- The two manual defensive-copy lines previously required by
  `TestLimitFilter_CountAndMaxAge_ReadListFilter` are removed —
  the helper now owns the copy.
- Race-clean across the module:
  `go test -race -timeout 180s ./...` green.

## Notes
- `slices.Clone` is the right primitive here: it preserves the
  nil-vs-empty distinction so the JSON-patch broadcast path
  still encodes an empty list as `[]`, not `null`. A first-pass
  fix using `append([]meta.Object(nil), objs...)` collapsed
  empty-non-nil into nil and broke `TestStreamLimitFilter`'s
  initial-snapshot patch path until traced back to the encoding.
- Allocation cost is one slice clone per filter call (well below
  the JSON encoding that runs immediately downstream on the same
  hot path); the perf-sensitive truncation step is unchanged.

Closes #136.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)