### PR TITLE
Operation-aware post-write hook, fired before the broadcast

### DIFF
--- a/ooo.go
+++ b/ooo.go
@@ -205,6 +205,12 @@ const (
 // AfterWrite: callback function triggered after a successful write
 // (Set / Push / Patch / Del). Wired once at Start; further changes
 // have no effect.
+//
+// AfterWriteOp: operation-aware companion to AfterWrite, triggered with
+// the operation ("set" / "del") and, unlike AfterWrite, BEFORE the change
+// is broadcast to watchers — so a consumer can update derived per-key
+// state in place before any event-driven reactor observes the write. Also
+// wired once at Start; further changes have no effect.
 type Server struct {
 	wg           sync.WaitGroup
 	watchWg      sync.WaitGroup

--- a/ooo.go
+++ b/ooo.go
@@ -295,13 +295,14 @@ type Server struct {
 	OnDroppedEvent      func(ev storage.Event)        // optional: invoked when the sharded watcher channel drops an event after timing out
 	BeforeRead          func(key string)
 	AfterWrite          func(key string)
-	GetPivotInfo        func() *ui.PivotInfo // Optional: returns pivot status for UI
-	NoCompress          bool                 // Disable gzip compression (useful for tests)
-	WatchPanics         int64                // Atomic counter of panics recovered in watch goroutines
-	DroppedEvents       int64                // Atomic counter of events dropped by the sharded watcher on send timeout
-	startErr            chan error           // channel for startup errors
-	clockStop           chan struct{}        // channel to signal clock goroutine to stop
-	consoleAutoBuilt    bool                 // true when defaults() built Console (so post-Listen rebuild can swap address without clobbering a user-supplied Console)
+	AfterWriteOp        func(key string, op string) // optional: operation-aware companion to AfterWrite ("set"/"del")
+	GetPivotInfo        func() *ui.PivotInfo        // Optional: returns pivot status for UI
+	NoCompress          bool                        // Disable gzip compression (useful for tests)
+	WatchPanics         int64                       // Atomic counter of panics recovered in watch goroutines
+	DroppedEvents       int64                       // Atomic counter of events dropped by the sharded watcher on send timeout
+	startErr            chan error                  // channel for startup errors
+	clockStop           chan struct{}               // channel to signal clock goroutine to stop
+	consoleAutoBuilt    bool                        // true when defaults() built Console (so post-Listen rebuild can swap address without clobbering a user-supplied Console)
 }
 
 // Validate checks the server configuration for common issues.
@@ -464,6 +465,9 @@ func (server *Server) waitListen() {
 	}
 	if server.AfterWrite != nil {
 		storageOpt.AfterWrite = server.AfterWrite
+	}
+	if server.AfterWriteOp != nil {
+		storageOpt.AfterWriteOp = server.AfterWriteOp
 	}
 	err = server.Storage.Start(storageOpt)
 	if err != nil {

--- a/storage/afterwriteop_test.go
+++ b/storage/afterwriteop_test.go
@@ -3,8 +3,8 @@ package storage
 import (
 	"encoding/json"
 	"sync"
-	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -47,32 +47,98 @@ func TestAfterWriteOpReportsOperation(t *testing.T) {
 	require.Equal(t, "set", ops["things/"+pushed], "Push should report set")
 }
 
+// TestAfterWriteOpReportsGlobDelete covers the glob-delete path: Del on a glob
+// routes through delGlob, which fires a single "del" keyed on the glob path
+// itself — not on the expanded keys it removes. This mirrors the broadcast
+// event delGlob emits (Key = glob path, Object = nil), so a consumer reacting
+// off AfterWriteOp sees exactly what a broadcast subscriber sees.
+func TestAfterWriteOpReportsGlobDelete(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	ops := map[string]string{} // key -> last op
+
+	st := New(LayeredConfig{Memory: NewMemoryLayer()})
+	require.NoError(t, st.Start(Options{
+		AfterWriteOp: func(key string, op string) {
+			mu.Lock()
+			ops[key] = op
+			mu.Unlock()
+		},
+	}))
+	defer st.Close()
+
+	data := json.RawMessage(`{"v":1}`)
+	_, err := st.Set("things/a", data)
+	require.NoError(t, err)
+	_, err = st.Set("things/b", data)
+	require.NoError(t, err)
+
+	require.NoError(t, st.Del("things/*"))
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, "del", ops["things/*"], "glob Del fires one del keyed on the glob path")
+	// The expanded keys keep their prior "set" op — a per-expanded-key "del"
+	// hook would have overwritten them. delGlob fires once, on the glob path.
+	require.Equal(t, "set", ops["things/a"], "glob Del must not fire a per-key del for things/a")
+	require.Equal(t, "set", ops["things/b"], "glob Del must not fire a per-key del for things/b")
+}
+
 // TestAfterWriteOpFiresBeforeEvent locks the ordering the version-vector bump
 // depends on: AfterWriteOp runs BEFORE the storage event is broadcast, so a
 // consumer that updates derived state in it has that state in place before any
 // event-driven reactor (broadcast subscriber, async sync push) observes the
-// write. The event is not enqueued until after AfterWriteOp returns, so the
-// watch callback deterministically sees the hook's effect already applied.
+// write.
+//
+// The test parks the write goroutine inside the hook and asserts that no
+// storage event escapes to a watcher while it is parked. With the hook firing
+// before sendEvent, the broadcast cannot have run yet, so the window stays
+// silent; if the hook were moved after the broadcast, the already-enqueued
+// event would be delivered during the parked window and fail the test. (The
+// previous version only stored a flag and checked it from the watch callback —
+// it could never fail, because the synchronous hook always won the race against
+// the async watcher regardless of which side of sendEvent it sat on.)
 func TestAfterWriteOpFiresBeforeEvent(t *testing.T) {
 	t.Parallel()
 
-	var opRan atomic.Bool
+	inHook := make(chan struct{})
+	release := make(chan struct{})
 	st := New(LayeredConfig{Memory: NewMemoryLayer()})
 	require.NoError(t, st.Start(Options{
-		AfterWriteOp: func(key string, op string) { opRan.Store(true) },
+		AfterWriteOp: func(key string, op string) {
+			close(inHook)
+			<-release
+		},
 	}))
 	defer st.Close()
 
-	observed := make(chan bool, 1)
+	events := make(chan Event, 1)
 	WatchWithCallback(st, func(ev Event) {
 		select {
-		case observed <- opRan.Load():
+		case events <- ev:
 		default:
 		}
 	})
 
-	_, err := st.Set("test/order", json.RawMessage(`{"v":1}`))
-	require.NoError(t, err)
+	go func() { _, _ = st.Set("test/order", json.RawMessage(`{"v":1}`)) }()
 
-	require.True(t, <-observed, "AfterWriteOp must run before the storage event is delivered")
+	<-inHook // the write goroutine is now parked inside AfterWriteOp
+
+	// AfterWriteOp fires before sendEvent, so while the hook is parked the
+	// broadcast has not run. Hold it open long enough that an event enqueued
+	// before the hook (the inverted ordering) would surely have been delivered.
+	select {
+	case <-events:
+		t.Fatal("storage event broadcast before AfterWriteOp returned — ordering inverted")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	close(release) // let the write finish; the broadcast happens now
+
+	select {
+	case <-events:
+	case <-time.After(2 * time.Second):
+		t.Fatal("storage event never delivered after AfterWriteOp returned")
+	}
 }

--- a/storage/afterwriteop_test.go
+++ b/storage/afterwriteop_test.go
@@ -1,0 +1,78 @@
+package storage
+
+import (
+	"encoding/json"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestAfterWriteOpReportsOperation verifies the op-aware hook fires with the
+// correct operation for each write kind: Set / SetWithMeta / Push report
+// "set", Del reports "del".
+func TestAfterWriteOpReportsOperation(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	ops := map[string]string{} // key -> last op
+
+	st := New(LayeredConfig{Memory: NewMemoryLayer()})
+	require.NoError(t, st.Start(Options{
+		AfterWriteOp: func(key string, op string) {
+			mu.Lock()
+			ops[key] = op
+			mu.Unlock()
+		},
+	}))
+	defer st.Close()
+
+	data := json.RawMessage(`{"v":1}`)
+
+	_, err := st.Set("things/a", data)
+	require.NoError(t, err)
+	_, err = st.SetWithMeta("things/b", data, 1, 1)
+	require.NoError(t, err)
+	pushed, err := st.Push("things/*", data)
+	require.NoError(t, err)
+	require.NoError(t, st.Del("things/a"))
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, "del", ops["things/a"], "Set then Del should leave the del op")
+	require.Equal(t, "set", ops["things/b"], "SetWithMeta should report set")
+	// Push returns the leaf index; the hook (like the storage event) keys on
+	// the full path "things/<index>".
+	require.Equal(t, "set", ops["things/"+pushed], "Push should report set")
+}
+
+// TestAfterWriteOpFiresBeforeEvent locks the ordering the version-vector bump
+// depends on: AfterWriteOp runs BEFORE the storage event is broadcast, so a
+// consumer that updates derived state in it has that state in place before any
+// event-driven reactor (broadcast subscriber, async sync push) observes the
+// write. The event is not enqueued until after AfterWriteOp returns, so the
+// watch callback deterministically sees the hook's effect already applied.
+func TestAfterWriteOpFiresBeforeEvent(t *testing.T) {
+	t.Parallel()
+
+	var opRan atomic.Bool
+	st := New(LayeredConfig{Memory: NewMemoryLayer()})
+	require.NoError(t, st.Start(Options{
+		AfterWriteOp: func(key string, op string) { opRan.Store(true) },
+	}))
+	defer st.Close()
+
+	observed := make(chan bool, 1)
+	WatchWithCallback(st, func(ev Event) {
+		select {
+		case observed <- opRan.Load():
+		default:
+		}
+	})
+
+	_, err := st.Set("test/order", json.RawMessage(`{"v":1}`))
+	require.NoError(t, err)
+
+	require.True(t, <-observed, "AfterWriteOp must run before the storage event is delivered")
+}

--- a/storage/layered.go
+++ b/storage/layered.go
@@ -41,6 +41,27 @@ type Layered struct {
 	active          bool
 	beforeRead      func(key string)
 	afterWrite      func(key string)
+	afterWriteOp    func(key string, op string)
+}
+
+// fireAfterWriteOp invokes the operation-aware post-write hook. It runs BEFORE
+// the storage event is broadcast (see the call sites) so a consumer that
+// updates derived state in it — e.g. a version counter — has that state in
+// place before any event-driven reactor observes the write (a peer woken by
+// the broadcast, an async sync push, etc.). The legacy op-less AfterWrite
+// keeps its original position AFTER the broadcast (fireAfterWriteLegacy), so
+// existing consumers see no ordering change.
+func (l *Layered) fireAfterWriteOp(path string, op string) {
+	if l.afterWriteOp != nil {
+		l.afterWriteOp(path, op)
+	}
+}
+
+// fireAfterWriteLegacy invokes the op-less AfterWrite hook, after the broadcast.
+func (l *Layered) fireAfterWriteLegacy(path string) {
+	if l.afterWrite != nil {
+		l.afterWrite(path)
+	}
 }
 
 // NewLayered creates a new layered storage
@@ -92,6 +113,7 @@ func (l *Layered) Start(opt Options) error {
 	l.noBroadcastKeys = opt.NoBroadcastKeys
 	l.beforeRead = opt.BeforeRead
 	l.afterWrite = opt.AfterWrite
+	l.afterWriteOp = opt.AfterWriteOp
 
 	// Start layers from slowest to fastest
 	if l.embedded != nil {
@@ -530,12 +552,11 @@ func (l *Layered) setLocked(path string, data json.RawMessage) (string, error) {
 		return index, err
 	}
 
+	l.fireAfterWriteOp(path, "set")
 	if !key.Contains(l.noBroadcastKeys, path) && l.Active() {
 		l.sendEvent(Event{Key: path, Operation: "set", Object: obj})
 	}
-	if l.afterWrite != nil {
-		l.afterWrite(path)
-	}
+	l.fireAfterWriteLegacy(path)
 
 	return index, nil
 }
@@ -661,12 +682,11 @@ func (l *Layered) Push(path string, data json.RawMessage) (string, error) {
 		return index, err
 	}
 
+	l.fireAfterWriteOp(newPath, "set")
 	if !key.Contains(l.noBroadcastKeys, newPath) && l.Active() {
 		l.sendEvent(Event{Key: newPath, Operation: "set", Object: obj})
 	}
-	if l.afterWrite != nil {
-		l.afterWrite(newPath)
-	}
+	l.fireAfterWriteLegacy(newPath)
 
 	return index, nil
 }
@@ -695,12 +715,11 @@ func (l *Layered) SetWithMeta(path string, data json.RawMessage, created, update
 		return index, err
 	}
 
+	l.fireAfterWriteOp(path, "set")
 	if !key.Contains(l.noBroadcastKeys, path) && l.Active() {
 		l.sendEvent(Event{Key: path, Operation: "set", Object: obj})
 	}
-	if l.afterWrite != nil {
-		l.afterWrite(path)
-	}
+	l.fireAfterWriteLegacy(path)
 
 	return index, nil
 }
@@ -726,12 +745,11 @@ func (l *Layered) Del(path string) error {
 		return err
 	}
 
+	l.fireAfterWriteOp(path, "del")
 	if !key.Contains(l.noBroadcastKeys, path) && l.Active() {
 		l.sendEvent(Event{Key: path, Operation: "del", Object: obj})
 	}
-	if l.afterWrite != nil {
-		l.afterWrite(path)
-	}
+	l.fireAfterWriteLegacy(path)
 
 	return nil
 }
@@ -748,12 +766,11 @@ func (l *Layered) delGlob(path string) error {
 		return err
 	}
 
+	l.fireAfterWriteOp(path, "del")
 	if !key.Contains(l.noBroadcastKeys, path) && l.Active() {
 		l.sendEvent(Event{Key: path, Operation: "del", Object: nil})
 	}
-	if l.afterWrite != nil {
-		l.afterWrite(path)
-	}
+	l.fireAfterWriteLegacy(path)
 
 	return nil
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -44,7 +44,15 @@ type Options struct {
 	NoBroadcastKeys []string
 	BeforeRead      func(key string)
 	AfterWrite      func(key string)
-	Workers         int
+	// AfterWriteOp is an operation-aware companion to AfterWrite, invoked after
+	// a successful write with the operation ("set" or "del"). It fires in
+	// addition to AfterWrite (both run when both are set). Consumers that must
+	// react differently to sets vs deletes — e.g. clearing per-operation
+	// bookkeeping for exactly the operation that occurred — use this instead of
+	// trying to infer the operation, which AfterWrite alone cannot convey and a
+	// storage read-back cannot determine race-free.
+	AfterWriteOp func(key string, op string)
+	Workers      int
 }
 
 // ShardedChan manages multiple channels for per-key ordering.


### PR DESCRIPTION
## Summary
Closes #138 — adds an optional operation-aware post-write callback so a consumer can react to each change knowing whether it was a write or a delete, with that reaction applied before the change is broadcast to watchers.

- New optional post-write callback reports the operation (set/delete) per change, on both the storage options and the server.
- It runs before the change is broadcast, so a consumer that updates derived per-key state (e.g. version counters) has that state in place before any watcher-driven reaction observes the change.
- A glob delete reports a single delete keyed on the glob path — mirroring the broadcast event for that operation rather than firing once per matched key.
- The existing operation-less post-write callback is unchanged for current users — same firing point (after the broadcast), same behavior.

## Test plan
- [x] The new hook reports "set" for writes (set / set-with-meta / push) and "del" for deletes.
- [x] A glob delete reports a single "del" on the glob path and leaves the matched keys' prior op untouched (no per-matched-key delete).
- [x] The new hook fires before the storage event is delivered to watchers — guarded by a test that fails if the hook is moved after the broadcast.
- [x] Full storage suite passes under the race detector; existing post-write callback behavior unchanged.

## Known non-blockers (follow-ups)
- The operation-aware callback can only be wired at server start; a server whose storage is already running cannot attach it afterwards. This change intentionally delivers it through start-time configuration — attaching it to an already-running storage would be a separate change.
- A patch is reported as a "set" (at the storage layer a patch is a write). A consumer that needs to tell a patch apart from a plain set would need a follow-up.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)