### PR TITLE
Optional TLS serving and CA-trusting client

### DIFF
--- a/ooo.go
+++ b/ooo.go
@@ -2,6 +2,7 @@ package ooo
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"log"
 	"net"
@@ -278,13 +279,25 @@ type Server struct {
 	// state machine so Active() can distinguish "Start has been called
 	// but the listener has not yet bound" from "listener bound and
 	// serving". See StartWithError for the CAS that claims the slot.
-	active              int64
-	Silence             bool
-	Static              bool
-	Tick                time.Duration
-	Console             *coat.Console
-	Signal              chan os.Signal
-	Client              *http.Client
+	active  int64
+	Silence bool
+	Static  bool
+	Tick    time.Duration
+	Console *coat.Console
+	Signal  chan os.Signal
+	Client  *http.Client
+	// CertFile and KeyFile, when both non-empty, switch the listener
+	// from plaintext HTTP to HTTPS. The keypair is loaded once at Start;
+	// a load failure aborts startup with an error rather than serving
+	// plaintext. Leave both empty to serve plain HTTP (the default).
+	CertFile string
+	KeyFile  string
+	// TLSConfig, when non-nil, is the base TLS configuration for the
+	// HTTPS listener (min version, cipher suites, client-auth, ...). The
+	// keypair loaded from CertFile/KeyFile is appended to its
+	// Certificates. When nil a minimal modern default (TLS 1.2 floor) is
+	// used. Ignored when CertFile/KeyFile are empty.
+	TLSConfig           *tls.Config
 	ReadTimeout         time.Duration
 	WriteTimeout        time.Duration
 	ReadHeaderTimeout   time.Duration
@@ -493,6 +506,30 @@ func (server *Server) waitListen() {
 			// AllowCredentials: true,
 			// Debug:          true,
 		}).Handler(handler)}
+	// When a keypair is configured the server serves HTTPS. Load it
+	// before binding so a bad cert/key aborts startup with an error
+	// instead of falling through to a plaintext listener.
+	tlsEnabled := server.CertFile != "" && server.KeyFile != ""
+	if tlsEnabled {
+		cert, certErr := tls.LoadX509KeyPair(server.CertFile, server.KeyFile)
+		if certErr != nil {
+			atomic.StoreInt64(&server.active, serverInactive)
+			server.startErr <- fmt.Errorf("ooo: failed to load TLS keypair: %w", certErr)
+			server.wg.Done()
+			return
+		}
+		tlsConf := server.TLSConfig
+		if tlsConf == nil {
+			tlsConf = &tls.Config{}
+		} else {
+			tlsConf = tlsConf.Clone()
+		}
+		if tlsConf.MinVersion == 0 {
+			tlsConf.MinVersion = tls.VersionTLS12
+		}
+		tlsConf.Certificates = append(tlsConf.Certificates, cert)
+		server.server.TLSConfig = tlsConf
+	}
 	ln, err := net.Listen("tcp4", server.Address)
 	if err != nil {
 		// Roll the CAS claim back so a retry (or Start-after-Close)
@@ -507,7 +544,14 @@ func (server *Server) waitListen() {
 	server.Address = ln.Addr().String()
 	atomic.StoreInt64(&server.active, serverActive)
 	server.wg.Done()
-	err = server.server.Serve(tcpKeepAliveListener{ln.(*net.TCPListener)})
+	keepAliveLn := tcpKeepAliveListener{ln.(*net.TCPListener)}
+	if tlsEnabled {
+		// Cert/key already loaded into server.server.TLSConfig above, so
+		// pass empty filenames — ServeTLS uses the configured keypair.
+		err = server.server.ServeTLS(keepAliveLn, "", "")
+	} else {
+		err = server.server.Serve(keepAliveLn)
+	}
 	if atomic.LoadInt64(&server.closing) != 1 && err != nil {
 		server.Console.Err("server error", err)
 	}
@@ -732,22 +776,29 @@ func (server *Server) defaultCallbacks() {
 }
 
 // defaultClient sets up the default HTTP client.
+// defaultTransport builds the http.Transport used by the server's
+// outbound Client. Shared by defaultClient and NewClient so connection
+// tuning stays consistent whether or not a custom TLS root pool is set.
+func defaultTransport() *http.Transport {
+	return &http.Transport{
+		Dial: (&net.Dialer{
+			Timeout:   1 * time.Second,
+			KeepAlive: 10 * time.Second,
+		}).Dial,
+		IdleConnTimeout:       10 * time.Second,
+		ResponseHeaderTimeout: 10 * time.Second,
+		MaxConnsPerHost:       3000,
+		MaxIdleConns:          10000,
+		MaxIdleConnsPerHost:   1000,
+		DisableKeepAlives:     false,
+	}
+}
+
 func (server *Server) defaultClient() {
 	if server.Client == nil {
 		server.Client = &http.Client{
-			Timeout: 10 * time.Second,
-			Transport: &http.Transport{
-				Dial: (&net.Dialer{
-					Timeout:   1 * time.Second,
-					KeepAlive: 10 * time.Second,
-				}).Dial,
-				IdleConnTimeout:       10 * time.Second,
-				ResponseHeaderTimeout: 10 * time.Second,
-				MaxConnsPerHost:       3000,
-				MaxIdleConns:          10000,
-				MaxIdleConnsPerHost:   1000,
-				DisableKeepAlives:     false,
-			},
+			Timeout:   10 * time.Second,
+			Transport: defaultTransport(),
 		}
 	}
 }

--- a/tls.go
+++ b/tls.go
@@ -1,0 +1,58 @@
+package ooo
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+)
+
+// LoadCertPool builds an x509 certificate pool seeded with the host's
+// system roots and extended with the PEM certificate files at caPaths.
+// Use it to trust a private certificate authority in addition to the
+// public roots. If the system pool is unavailable (some minimal
+// containers) an empty pool is used so only caPaths are trusted.
+func LoadCertPool(caPaths ...string) (*x509.CertPool, error) {
+	pool, err := x509.SystemCertPool()
+	if err != nil || pool == nil {
+		pool = x509.NewCertPool()
+	}
+	for _, path := range caPaths {
+		pem, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return nil, fmt.Errorf("ooo: failed to read CA file %q: %w", path, readErr)
+		}
+		if !pool.AppendCertsFromPEM(pem) {
+			return nil, fmt.Errorf("ooo: no valid certificate found in CA file %q", path)
+		}
+	}
+	return pool, nil
+}
+
+// NewClient returns an http.Client tuned like the server's default
+// outbound client, but whose TLS configuration trusts the certificate
+// authorities at caPaths (in addition to the system roots). Assign the
+// result to Server.Client before Start so inter-service HTTPS calls
+// validate certificates signed by a private authority.
+//
+// A timeout of zero applies the default 10s request timeout.
+func NewClient(timeout time.Duration, caPaths ...string) (*http.Client, error) {
+	pool, err := LoadCertPool(caPaths...)
+	if err != nil {
+		return nil, err
+	}
+	transport := defaultTransport()
+	transport.TLSClientConfig = &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		RootCAs:    pool,
+	}
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: transport,
+	}, nil
+}

--- a/tls_test.go
+++ b/tls_test.go
@@ -1,0 +1,152 @@
+package ooo
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeTestCA generates a self-signed CA plus a leaf certificate with an
+// IP SAN, writes them to dir, and returns (caPath, certPath, keyPath).
+// This mirrors what the private certificate authority issues: a leaf
+// stamped with the machine's IP so https://<ip> validates.
+func writeTestCA(t *testing.T, dir string, ip net.IP) (string, string, string) {
+	t.Helper()
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-authority"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leafTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: ip.String()},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{ip},
+	}
+	caCert, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, caCert, &leafKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	caPath := filepath.Join(dir, "ca.crt")
+	certPath := filepath.Join(dir, "leaf.crt")
+	keyPath := filepath.Join(dir, "leaf.key")
+
+	writePEM(t, caPath, "CERTIFICATE", caDER)
+	writePEM(t, certPath, "CERTIFICATE", leafDER)
+	leafKeyDER, err := x509.MarshalECPrivateKey(leafKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writePEM(t, keyPath, "EC PRIVATE KEY", leafKeyDER)
+
+	return caPath, certPath, keyPath
+}
+
+func writePEM(t *testing.T, path, blockType string, der []byte) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if err := pem.Encode(f, &pem.Block{Type: blockType, Bytes: der}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestServerTLS proves the full HTTPS loop: a server configured with a
+// keypair serves TLS, a client built via NewClient (trusting the CA)
+// completes the handshake, and a client that does not trust the CA is
+// rejected — confirming the listener is genuinely encrypted, not plain.
+func TestServerTLS(t *testing.T) {
+	dir := t.TempDir()
+	caPath, certPath, keyPath := writeTestCA(t, dir, net.ParseIP("127.0.0.1"))
+
+	server := Server{
+		CertFile: certPath,
+		KeyFile:  keyPath,
+		Silence:  true,
+	}
+	server.Start("127.0.0.1:0")
+	defer server.Close(os.Interrupt)
+	if !server.Active() {
+		t.Fatal("server did not become active")
+	}
+
+	url := "https://" + server.Address + "/"
+
+	// Trusting client: handshake must succeed (any HTTP status is fine —
+	// reaching a response proves TLS termination worked).
+	trusting, err := NewClient(2*time.Second, caPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := trusting.Get(url)
+	if err != nil {
+		t.Fatalf("trusting client failed over HTTPS: %v", err)
+	}
+	resp.Body.Close()
+
+	// Non-trusting client: must be rejected at TLS verification.
+	untrusting := &http.Client{Timeout: 2 * time.Second}
+	if _, err := untrusting.Get(url); err == nil {
+		t.Fatal("expected non-trusting client to be rejected, got success")
+	} else if !strings.Contains(err.Error(), "certificate") {
+		t.Fatalf("expected a certificate verification error, got: %v", err)
+	}
+}
+
+// TestServerTLSBadKeypairFailsStart proves a bad keypair aborts startup
+// rather than silently falling back to a plaintext listener.
+func TestServerTLSBadKeypairFailsStart(t *testing.T) {
+	server := Server{
+		CertFile: "/nonexistent/cert.pem",
+		KeyFile:  "/nonexistent/key.pem",
+		Silence:  true,
+	}
+	err := server.StartWithError("127.0.0.1:0")
+	if err == nil {
+		server.Close(os.Interrupt)
+		t.Fatal("expected StartWithError to fail on missing keypair")
+	}
+	if !strings.Contains(err.Error(), "TLS keypair") {
+		t.Fatalf("expected TLS keypair error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## What

Adds opt-in HTTPS to the server and a matching trusting client, so a deployment can serve and consume traffic over TLS without an external reverse proxy.

- **`Server.CertFile` / `Server.KeyFile`** (+ optional `Server.TLSConfig`): when both paths are set, the server serves HTTPS. The keypair is loaded **before** the listener binds, so a bad/missing cert aborts startup with an error rather than silently falling back to plaintext. Defaults are unchanged — leave them empty and the server serves plain HTTP exactly as before.
- **`LoadCertPool(caPaths...)`**: builds a pool from the system roots plus extra PEM CA files — for trusting a private certificate authority.
- **`NewClient(timeout, caPaths...)`**: an `http.Client` tuned like the server's default outbound client but trusting those CAs, for calling peers over HTTPS.
- Shared `defaultTransport()` so the default client and `NewClient` stay in sync.

## Why

Lets a server serve HTTPS directly (modern TLS floor, caller-overridable) and call HTTPS peers signed by a private authority, with no plaintext fallback when TLS is configured.

## Tests

`tls_test.go`: a CA-trusting client completes the HTTPS handshake, a non-trusting client is rejected at verification (proving the listener is genuinely encrypted), and a bad keypair aborts startup. Full suite + vet green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)