### PR TITLE
feat(client): add SubscribeConfig.TLSConfig for wss with custom CAs

### DIFF
--- a/client/subscribe.go
+++ b/client/subscribe.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"net/http"
 	"net/url"
@@ -68,15 +69,20 @@ type RetryConfig struct {
 
 // SubscribeConfig holds connection configuration for Subscribe.
 // Required fields: Ctx, Server.
-// Optional fields: Header, HandshakeTimeout, Retry, Silence.
+// Optional fields: Header, HandshakeTimeout, Retry, Silence, TLSConfig.
 type SubscribeConfig struct {
 	Ctx              context.Context
 	Server           Server
 	Header           http.Header
 	HandshakeTimeout time.Duration
 	Retry            RetryConfig
-	Silence          bool          // if true, suppresses log output
-	console          *coat.Console // internal console for logging
+	Silence          bool // if true, suppresses log output
+	// TLSConfig, when set, is used for the "wss" websocket handshake. Leave
+	// nil to use the system cert pool (the default). Set RootCAs to trust an
+	// internal/self-signed CA (e.g. via x509.SystemCertPool + AppendCertsFromPEM,
+	// or a test CA) when the peer serves TLS with a non-public certificate.
+	TLSConfig *tls.Config
+	console   *coat.Console // internal console for logging
 }
 
 // Validate checks that required fields are set and applies defaults.
@@ -171,6 +177,7 @@ func (s *subscribeState[T]) connect() bool {
 	dialer := &websocket.Dialer{
 		Proxy:            http.ProxyFromEnvironment,
 		HandshakeTimeout: s.cfg.HandshakeTimeout,
+		TLSClientConfig:  s.cfg.TLSConfig,
 	}
 
 	s.muClient.Lock()
@@ -357,6 +364,7 @@ func (s *subscribeListState[T]) connect() bool {
 	dialer := &websocket.Dialer{
 		Proxy:            http.ProxyFromEnvironment,
 		HandshakeTimeout: s.cfg.HandshakeTimeout,
+		TLSClientConfig:  s.cfg.TLSConfig,
 	}
 
 	s.muClient.Lock()

--- a/client/subscribe_tls_test.go
+++ b/client/subscribe_tls_test.go
@@ -1,0 +1,131 @@
+package client_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/benitogf/ooo"
+	"github.com/benitogf/ooo/client"
+	"github.com/stretchr/testify/require"
+)
+
+// genServerTLS mints a self-signed CA + a leaf with an IP SAN, writes the
+// leaf keypair to disk for the server, and returns a CertPool trusting the
+// CA — mirroring how the private authority issues an internal cert.
+func genServerTLS(t *testing.T, ip net.IP) (certPath, keyPath string, caPool *x509.CertPool) {
+	t.Helper()
+	dir := t.TempDir()
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-authority"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+	caCert, err := x509.ParseCertificate(caDER)
+	require.NoError(t, err)
+
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	leafTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: ip.String()},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{ip},
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, caCert, &leafKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	certPath = filepath.Join(dir, "leaf.crt")
+	keyPath = filepath.Join(dir, "leaf.key")
+	writePEMBlock(t, certPath, "CERTIFICATE", leafDER)
+	leafKeyDER, err := x509.MarshalECPrivateKey(leafKey)
+	require.NoError(t, err)
+	writePEMBlock(t, keyPath, "EC PRIVATE KEY", leafKeyDER)
+
+	caPool = x509.NewCertPool()
+	caPool.AddCert(caCert)
+	return certPath, keyPath, caPool
+}
+
+func writePEMBlock(t *testing.T, path, blockType string, der []byte) {
+	t.Helper()
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	defer f.Close()
+	require.NoError(t, pem.Encode(f, &pem.Block{Type: blockType, Bytes: der}))
+}
+
+// TestSubscribeListWSSWithTLSConfig proves SubscribeConfig.TLSConfig lets a
+// wss subscription trust an internal/self-signed CA: with the CA pool the
+// handshake succeeds and the initial snapshot is delivered; without it the
+// dial is rejected at TLS verification.
+func TestSubscribeListWSSWithTLSConfig(t *testing.T) {
+	certPath, keyPath, caPool := genServerTLS(t, net.ParseIP("127.0.0.1"))
+
+	server := ooo.Server{Silence: true, CertFile: certPath, KeyFile: keyPath}
+	server.Start("127.0.0.1:0")
+	defer server.Close(os.Interrupt)
+	require.True(t, server.Active())
+
+	// With the trusting TLSConfig: the wss handshake completes and the
+	// initial (empty) snapshot fires OnMessage. A trust failure would hang
+	// here until the test times out.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go client.SubscribeList(client.SubscribeConfig{
+		Ctx:       t.Context(),
+		Server:    client.Server{Protocol: "wss", Host: server.Address},
+		Silence:   true,
+		TLSConfig: &tls.Config{RootCAs: caPool},
+	}, "devices/*", client.SubscribeListEvents[Device]{
+		OnMessage: func([]client.Meta[Device]) { wg.Done() },
+	})
+	wg.Wait()
+
+	// Without any TLSConfig: the system pool does not trust the self-signed
+	// CA, so the dial must be rejected with a certificate error.
+	errCh := make(chan error, 4)
+	go client.SubscribeList(client.SubscribeConfig{
+		Ctx:     t.Context(),
+		Server:  client.Server{Protocol: "wss", Host: server.Address},
+		Silence: true,
+	}, "devices/*", client.SubscribeListEvents[Device]{
+		OnMessage: func([]client.Meta[Device]) {},
+		OnError: func(e error) {
+			select {
+			case errCh <- e:
+			default:
+			}
+		},
+	})
+	select {
+	case e := <-errCh:
+		require.Error(t, e)
+		require.Contains(t, e.Error(), "certificate")
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected a certificate verification error without TLSConfig, got none")
+	}
+}


### PR DESCRIPTION
## Problem

`client.Subscribe` / `client.SubscribeList` build their `websocket.Dialer` with no `TLSClientConfig`, so a `wss` connection always validates against Go's **system cert pool**. There's no way to subscribe over `wss` to a peer that serves TLS with an internal/self-signed certificate unless that CA is installed in the OS trust store. That blocks:
- tests that serve TLS with an ephemeral CA, and
- any client that wants to trust an internal authority explicitly rather than via the OS store.

## Change

Add an optional `TLSConfig *tls.Config` field to `SubscribeConfig`, wired into the `websocket.Dialer.TLSClientConfig` in both `connect()` paths (`subscribeState` and `subscribeListState`).

- **Backward compatible:** `nil` (the zero value) preserves the previous behavior — the dialer uses the system cert pool.
- Set `TLSConfig.RootCAs` to trust an internal/self-signed CA.

## Test

`TestSubscribeListWSSWithTLSConfig` starts an `ooo.Server` with a self-signed leaf (IP SAN) and proves the `wss` handshake **succeeds** with a trusting `TLSConfig{RootCAs}` and is **rejected with a certificate error** without one. Full `client` package + `go vet` green; `-race` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)