### PR TITLE
refactor(server)!: remove Server.Audit, use Router.Use() middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ For large-scale data storage (millions of records, complex queries), use a dedic
 - [JSON Patch](http://jsonpatch.com) updates for efficient sync
 - Version checking (no data sent on version match while reconnecting)
 - RESTful CRUD reflected to subscribers
-- Filtering and audit middleware
+- Filtering and Router.Use() middleware
 - Auto-managed timestamps (created, updated) with a monotonic clock for consistency on ntp/ptp synchronizations
 - Built-in web UI for data management
 
@@ -249,13 +249,29 @@ server.LimitFilter("telemetry/*", ooo.LimitFilterConfig{
 - `Description` - Human-readable description for the explorer UI
 - `Schema` - JSON schema struct for UI display
 
-### Audit
+### Middleware
+
+Gate requests by registering standard `http.Handler` middleware via
+`server.Router.Use(...)`. The chain is built into the matched handler
+by gorilla/mux, so it runs for every matched request — REST handlers,
+WebSocket upgrades, custom endpoints, proxy routes, and the explorer
+UI all dispatch through the chain. Unmatched paths (404/405) skip
+the chain, matching gorilla/mux's own behavior. Subrouters work as
+expected for per-prefix chains.
 
 ```go
-server.Audit = func(r *http.Request) bool {
-    // return true to allow, false to deny (401)
-    return r.Header.Get("X-API-Key") == "secret"
-}
+import "github.com/gorilla/mux"
+
+server.Router = mux.NewRouter()
+server.Router.Use(func(next http.Handler) http.Handler {
+    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        if r.Header.Get("X-API-Key") != "secret" {
+            w.WriteHeader(http.StatusUnauthorized)
+            return
+        }
+        next.ServeHTTP(w, r)
+    })
+})
 ```
 
 ### Custom Endpoints

--- a/clock.go
+++ b/clock.go
@@ -1,7 +1,6 @@
 package ooo
 
 import (
-	"fmt"
 	"net/http"
 	"strconv"
 	"time"
@@ -38,13 +37,6 @@ func (server *Server) startClock() {
 }
 
 func (server *Server) clock(w http.ResponseWriter, r *http.Request) {
-	if !server.Audit(r) {
-		w.WriteHeader(http.StatusUnauthorized)
-		fmt.Fprintf(w, "%s", ErrNotAuthorized)
-		server.Console.Err("socketConnectionUnauthorized time")
-		return
-	}
-
 	server.handlerWg.Add(1)
 	defer server.handlerWg.Done()
 

--- a/clock_test.go
+++ b/clock_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/require"
 )
@@ -67,9 +68,12 @@ func TestClockWebsocketUnauthorized(t *testing.T) {
 	}
 	server := Server{}
 	server.Silence = true
-	server.Audit = func(r *http.Request) bool {
-		return false // Deny all requests
-	}
+	server.Router = mux.NewRouter()
+	server.Router.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		})
+	})
 	server.Start("localhost:0")
 	defer server.Close(os.Interrupt)
 

--- a/endpoint.go
+++ b/endpoint.go
@@ -1,7 +1,6 @@
 package ooo
 
 import (
-	"fmt"
 	"net/http"
 	"regexp"
 
@@ -56,26 +55,6 @@ func extractPathVars(path string) Vars {
 	return vars
 }
 
-// AuditHandler wraps next so the configured Server.Audit gate runs
-// before the handler. Returns 401 Unauthorized when Audit denies the
-// request. Used by Endpoint registration and the proxy package so
-// custom routes participate in the same auth/rate-limit/observability
-// path as the built-in REST handlers.
-//
-// The nil-Audit branch is defensive for direct-Router test paths
-// (ServeHTTP bypassing Start). Production callers reach this wrapper
-// only after Start has populated the default Audit via defaults().
-func (server *Server) AuditHandler(next http.HandlerFunc) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		if server.Audit != nil && !server.Audit(r) {
-			w.WriteHeader(http.StatusUnauthorized)
-			fmt.Fprintf(w, "%s", ErrNotAuthorized)
-			return
-		}
-		next(w, r)
-	}
-}
-
 // Endpoint registers a custom HTTP endpoint with metadata for UI visibility
 func (server *Server) Endpoint(cfg EndpointConfig) {
 	methods := make([]string, 0, len(cfg.Methods))
@@ -102,12 +81,13 @@ func (server *Server) Endpoint(cfg EndpointConfig) {
 
 	// Register route with router and mirror onto the route oracle so the
 	// data wildcard defers to this Endpoint regardless of registration
-	// order. Wrap the handler in AuditHandler so Server.Audit gates the
-	// custom path the same way it gates the built-in REST handlers.
-	// RouterMutate serializes this with the syncRouter wrapper's Match
-	// so concurrent request dispatch is race-free.
+	// order. Any middleware registered via server.Router.Use(...) is
+	// applied by gorilla/mux's Match before dispatch — no per-handler
+	// wrapper is needed here. RouterMutate serializes this with the
+	// syncRouter wrapper's Match so concurrent request dispatch is
+	// race-free.
 	server.RouterMutate(func() {
-		server.Router.HandleFunc(cfg.Path, server.AuditHandler(cfg.Handler)).Methods(methods...)
+		server.Router.HandleFunc(cfg.Path, cfg.Handler).Methods(methods...)
 	})
 	server.RegisterOracleRoute(cfg.Path, methods)
 

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -9,12 +9,14 @@ import (
 	"os"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/benitogf/go-json"
 	"github.com/benitogf/ooo"
 	"github.com/benitogf/ooo/ui"
+	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/require"
 )
@@ -167,30 +169,43 @@ func TestRegisterProxyConcurrentWithRead(t *testing.T) {
 	wg.Wait()
 }
 
-// TestAuditGatesEndpoint asserts that a custom Endpoint registered
-// via Server.Endpoint honors Server.Audit. Pre-fix the endpoint
-// handler was registered directly on Router with no Audit wrapping,
-// so a deny-everything Audit had no effect — custom endpoint paths
-// silently bypassed auth/rate-limiting/observability gates that
-// every REST handler already respects.
-func TestAuditGatesEndpoint(t *testing.T) {
+// denyAllMiddleware returns a middleware that rejects every request
+// with 401 Unauthorized. Used by tests that assert a registered
+// middleware actually gates the matched handler.
+func denyAllMiddleware() mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		})
+	}
+}
+
+// TestMiddlewareGatesEndpoint asserts that a custom Endpoint
+// registered via Server.Endpoint runs inside the middleware chain
+// registered via Router.Use(). Pre-refactor the Endpoint handler was
+// wrapped in an opinionated AuditHandler that consulted a separate
+// Server.Audit hook; now the gorilla/mux middleware chain is the
+// single extension point and the Endpoint handler is registered
+// naked.
+func TestMiddlewareGatesEndpoint(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Parallel()
 	}
 	server := ooo.Server{}
 	server.Silence = true
-	server.Audit = func(r *http.Request) bool { return false }
+	server.Router = mux.NewRouter()
+	server.Router.Use(denyAllMiddleware())
 	server.Start("localhost:0")
 	defer server.Close(os.Interrupt)
 
-	var handlerRan bool
+	var handlerRan atomic.Bool
 	server.Endpoint(ooo.EndpointConfig{
 		Path: "/custom",
 		Methods: ooo.Methods{
 			http.MethodGet: {Response: nil},
 		},
 		Handler: func(w http.ResponseWriter, _ *http.Request) {
-			handlerRan = true
+			handlerRan.Store(true)
 			w.WriteHeader(http.StatusOK)
 		},
 	})
@@ -199,19 +214,42 @@ func TestAuditGatesEndpoint(t *testing.T) {
 	w := httptest.NewRecorder()
 	server.Router.ServeHTTP(w, req)
 	require.Equal(t, http.StatusUnauthorized, w.Result().StatusCode,
-		"Audit returning false must reject custom Endpoint requests")
-	require.False(t, handlerRan, "Endpoint handler must not run when Audit denies")
+		"middleware returning 401 must reject custom Endpoint requests")
+	require.False(t, handlerRan.Load(),
+		"Endpoint handler must not run when middleware denies")
 }
 
-func TestAudit(t *testing.T) {
+// TestMiddleware exercises Router.Use() middleware across every
+// request type the server dispatches: storage REST (GET, POST,
+// DELETE), the explorer root, and a WebSocket subscription upgrade.
+// All must be gated by the same chain.
+func TestMiddleware(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Parallel()
 	}
 	server := ooo.Server{}
 	server.Silence = true
-	server.Audit = func(r *http.Request) bool {
+	server.Router = mux.NewRouter()
+
+	// gate is swapped between phases of the test; the middleware
+	// closes over the atomic pointer so changes take effect on the
+	// next request without re-registering.
+	var gate atomic.Pointer[func(*http.Request) bool]
+	initial := func(r *http.Request) bool {
 		return r.Header.Get("Upgrade") != "websocket" && r.Method != "GET" && r.Method != "DELETE"
 	}
+	gate.Store(&initial)
+	server.Router.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fn := gate.Load()
+			if fn != nil && !(*fn)(r) {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	})
+
 	server.Start("localhost:0")
 	defer server.Close(os.Interrupt)
 
@@ -219,50 +257,52 @@ func TestAudit(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "test", index)
 
+	// GET /test → denied
 	req := httptest.NewRequest("GET", "/test", nil)
 	w := httptest.NewRecorder()
 	server.Router.ServeHTTP(w, req)
-	resp := w.Result()
-	require.Equal(t, 401, resp.StatusCode)
+	require.Equal(t, http.StatusUnauthorized, w.Result().StatusCode)
 
+	// GET / (explorer root) → denied
 	req = httptest.NewRequest("GET", "/", nil)
 	w = httptest.NewRecorder()
 	server.Router.ServeHTTP(w, req)
-	resp = w.Result()
-	require.Equal(t, 401, resp.StatusCode)
+	require.Equal(t, http.StatusUnauthorized, w.Result().StatusCode)
 
+	// DELETE /test → denied
 	req = httptest.NewRequest("DELETE", "/test", nil)
 	w = httptest.NewRecorder()
 	server.Router.ServeHTTP(w, req)
-	resp = w.Result()
-	require.Equal(t, 401, resp.StatusCode)
+	require.Equal(t, http.StatusUnauthorized, w.Result().StatusCode)
 
+	// WebSocket subscribe → upgrade refused (middleware returns 401
+	// before the handler can hijack).
 	u := url.URL{Scheme: "ws", Host: server.Address, Path: "/sa/test"}
 	c, _, err := websocket.DefaultDialer.Dial(u.String(), nil)
 	require.Nil(t, c)
 	server.Console.Err(err)
 	require.Error(t, err)
 
-	server.Audit = func(r *http.Request) bool {
-		return r.Method == "GET"
-	}
+	// Flip the gate: only GET succeeds.
+	getOnly := func(r *http.Request) bool { return r.Method == "GET" }
+	gate.Store(&getOnly)
 
-	var jsonStr = []byte(`{"data":"test"}`)
+	jsonStr := []byte(`{"data":"test"}`)
 	req = httptest.NewRequest("POST", "/test", bytes.NewBuffer(jsonStr))
 	w = httptest.NewRecorder()
 	server.Router.ServeHTTP(w, req)
-	resp = w.Result()
-	require.Equal(t, 401, resp.StatusCode)
+	require.Equal(t, http.StatusUnauthorized, w.Result().StatusCode)
 
 	req = httptest.NewRequest("GET", "/test", nil)
 	w = httptest.NewRecorder()
 	server.Router.ServeHTTP(w, req)
-	resp = w.Result()
-	require.Equal(t, 200, resp.StatusCode)
+	require.Equal(t, http.StatusOK, w.Result().StatusCode)
 
-	server.Audit = func(r *http.Request) bool {
+	// Flip again: WebSocket explicitly denied.
+	noWS := func(r *http.Request) bool {
 		return r.Header.Get("Upgrade") != "websocket"
 	}
+	gate.Store(&noWS)
 
 	u = url.URL{Scheme: "ws", Host: server.Address, Path: "/"}
 	c, _, err = websocket.DefaultDialer.Dial(u.String(), nil)

--- a/ooo.go
+++ b/ooo.go
@@ -43,14 +43,17 @@ const deadlineMsg = "ooo: server deadline reached"
 // use mux.CurrentRoute, which gorilla/mux does not expose a public
 // setter for.
 //
+// Router.Use() middlewares fan out automatically: gorilla/mux's
+// Router.Match builds the middleware chain into match.Handler before
+// returning, so the dispatched handler is already wrapped. Consumers
+// gate requests by registering middleware via server.Router.Use(...);
+// no per-handler hook is needed.
+//
 // Known deviations from mux.Router.ServeHTTP:
 //   - No path cleaning + 301 redirect for non-canonical paths
 //     (mux does this when SkipClean(true) has NOT been set). The
 //     codebase does not depend on it. Add a port of mux's cleanPath
 //     here if a future consumer needs it.
-//   - mux Router.Use() middlewares are not fanned out. The codebase
-//     does not register any. If middleware support is added later,
-//     this wrapper must chain them onto the matched handler.
 type syncRouter struct {
 	router *mux.Router
 	mu     *sync.RWMutex
@@ -106,14 +109,6 @@ const (
 // (POST / PATCH). Override via Server.MaxRequestBodyBytes. Set the field to a
 // negative value to disable the cap.
 const DefaultMaxRequestBodyBytes = 10 * 1024 * 1024 // 10 MiB
-
-// audit requests function
-// will define approval or denial by the return value
-// r: the request to be audited
-// returns
-// true: approve the request
-// false: rejects the request
-type audit func(r *http.Request) bool
 
 // CloseHookPhase identifies when a teardown hook runs during Server.Close.
 // Phases run in declaration order; multiple hooks at the same phase run
@@ -245,7 +240,6 @@ type Server struct {
 	closeHooks      [closeHookPhaseCount][]func() // teardown hooks indexed by CloseHookPhase
 	closeHooksMu    sync.Mutex                    // protects closeHooks
 	NoBroadcastKeys []string
-	Audit           audit
 	Workers         int
 	ForcePatch      bool
 	NoPatch         bool
@@ -774,9 +768,6 @@ func (server *Server) defaultCallbacks() {
 	if server.OnClose == nil {
 		server.OnClose = func() {}
 	}
-	if server.Audit == nil {
-		server.Audit = func(r *http.Request) bool { return true }
-	}
 	if server.OnSubscribe == nil {
 		server.OnSubscribe = func(key string) error { return nil }
 	}
@@ -885,7 +876,6 @@ func (server *Server) setupRoutes() {
 		GetEndpoints:   server.getEndpoints,
 		GetProxies:     server.getProxies,
 		GetOrphanKeys:  server.getOrphanKeys,
-		AuditFunc:      server.Audit,
 		ClockFunc:      server.clock,
 	}
 	server.Router.Handle("/", explorerHandler).Methods("GET")

--- a/ooo.go
+++ b/ooo.go
@@ -47,7 +47,10 @@ const deadlineMsg = "ooo: server deadline reached"
 // Router.Match builds the middleware chain into match.Handler before
 // returning, so the dispatched handler is already wrapped. Consumers
 // gate requests by registering middleware via server.Router.Use(...);
-// no per-handler hook is needed.
+// no per-handler hook is needed. Unmatched paths (404 / 405) skip
+// the chain — matching gorilla/mux's own ServeHTTP behavior — so
+// observability middleware will not see those responses; wrap from
+// outside Server.Router if you need to.
 //
 // Known deviations from mux.Router.ServeHTTP:
 //   - No path cleaning + 301 redirect for non-canonical paths
@@ -143,8 +146,6 @@ const (
 // Stream: manages WebSocket connections and broadcasts
 //
 // NoBroadcastKeys: array of keys that should not broadcast on changes
-//
-// Audit: function to audit requests, returns true to approve, false to deny
 //
 // Workers: number of workers to use as readers of the storage->broadcast channel
 //

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -606,12 +606,13 @@ func Route(server *ooo.Server, localPath string, cfg Config) error {
 
 	// Register the route and mirror onto the route oracle so the data
 	// wildcard defers to this proxy regardless of registration order.
-	// AuditHandler runs Server.Audit before the proxy handler so
-	// proxied paths participate in the same auth gate as built-in
-	// REST handlers. RouterMutate serializes this with the
-	// syncRouter wrapper's Match.
+	// Auth gating is handled by middleware registered via
+	// server.Router.Use(...); gorilla/mux's Match applies the chain
+	// before dispatch, so the proxy handler runs after middleware just
+	// like built-in REST handlers. RouterMutate serializes this with
+	// the syncRouter wrapper's Match.
 	server.RouterMutate(func() {
-		server.Router.HandleFunc("/"+muxPattern, server.AuditHandler(handler))
+		server.Router.HandleFunc("/"+muxPattern, handler)
 	})
 	server.RegisterOracleRoute("/"+muxPattern, nil)
 
@@ -707,13 +708,14 @@ func RouteList(server *ooo.Server, localPath string, cfg Config) error {
 
 	// Register routes - specific path first, then base. Mirror both onto
 	// the route oracle so the data wildcard defers to them regardless of
-	// registration order. AuditHandler wraps each so Server.Audit gates
-	// proxied requests the same way it gates built-in REST handlers.
-	// RouterMutate serializes both mutations with the syncRouter
-	// wrapper's Match.
+	// registration order. Auth gating is handled by middleware registered
+	// via server.Router.Use(...); gorilla/mux's Match applies the chain
+	// before dispatch, so proxy handlers run after middleware like
+	// built-in REST handlers. RouterMutate serializes both mutations
+	// with the syncRouter wrapper's Match.
 	server.RouterMutate(func() {
-		server.Router.HandleFunc("/"+muxPattern, server.AuditHandler(itemHandler))
-		server.Router.HandleFunc("/"+basePath, server.AuditHandler(listHandler))
+		server.Router.HandleFunc("/"+muxPattern, itemHandler)
+		server.Router.HandleFunc("/"+basePath, listHandler)
 	})
 	server.RegisterOracleRoute("/"+muxPattern, nil)
 	server.RegisterOracleRoute("/"+basePath, nil)
@@ -989,8 +991,12 @@ func RouteWithVars(server *ooo.Server, localPath string, cfg Config) error {
 		handleHTTPProxy(server, w, r, address, remotePath, cfg.Subscribe)
 	}
 
+	// Auth gating is handled by middleware registered via
+	// server.Router.Use(...); gorilla/mux's Match applies the chain
+	// before dispatch, so this proxy handler runs after middleware
+	// like built-in REST handlers.
 	server.RouterMutate(func() {
-		server.Router.HandleFunc("/"+localPath, server.AuditHandler(handler))
+		server.Router.HandleFunc("/"+localPath, handler)
 	})
 	server.RegisterOracleRoute("/"+localPath, nil)
 

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/benitogf/ooo"
 	"github.com/benitogf/ooo/client"
 	"github.com/benitogf/ooo/proxy"
+	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/require"
 )
@@ -863,15 +864,18 @@ func TestProxyWebSocketWithBearerTokenAuthRequired(t *testing.T) {
 	remote.Silence = true
 	remote.Static = true
 	remote.OpenFilter("settings")
-	remote.Audit = func(r *http.Request) bool {
-		// Check for bearer token in Sec-Websocket-Protocol header
-		protocols := r.Header.Get("Sec-Websocket-Protocol")
-		if protocols == "" {
-			return false
-		}
-		// Protocol format: "bearer, <token>" - verify token is present
-		return strings.Contains(protocols, testToken)
-	}
+	remote.Router = mux.NewRouter()
+	remote.Router.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Check for bearer token in Sec-Websocket-Protocol header
+			protocols := r.Header.Get("Sec-Websocket-Protocol")
+			if protocols == "" || !strings.Contains(protocols, testToken) {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	})
 	remote.Start("localhost:0")
 	defer remote.Close(os.Interrupt)
 
@@ -1594,12 +1598,24 @@ func TestProxyCapabilitiesEnforcedViaNodeListFilter(t *testing.T) {
 	require.False(t, upstreamHit, "upstream must not see denied requests via NodeListFilter")
 }
 
-// TestProxyAuditGatesRoute asserts that a proxied request through
-// Route honors Server.Audit. Pre-fix proxy handlers were registered
-// directly on Router with no Audit wrapping, so a deny-everything
-// Audit had no effect — custom proxy paths silently bypassed
-// auth/rate-limiting/observability gates.
-func TestProxyAuditGatesRoute(t *testing.T) {
+// denyAllMiddleware rejects every request with 401 Unauthorized.
+// Used by the proxy gating tests below to assert middleware fans
+// out across every shape of proxy registration.
+func denyAllMiddleware() mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		})
+	}
+}
+
+// TestProxyMiddlewareGatesRoute asserts that a proxied request
+// through Route runs inside the middleware chain registered via
+// Router.Use(). Pre-refactor proxy handlers were wrapped in an
+// opinionated AuditHandler; now the gorilla/mux middleware chain is
+// the single extension point and the proxy handler is registered
+// naked.
+func TestProxyMiddlewareGatesRoute(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Parallel()
 	}
@@ -1613,7 +1629,8 @@ func TestProxyAuditGatesRoute(t *testing.T) {
 
 	proxyServer := &ooo.Server{}
 	proxyServer.Silence = true
-	proxyServer.Audit = func(r *http.Request) bool { return false }
+	proxyServer.Router = mux.NewRouter()
+	proxyServer.Router.Use(denyAllMiddleware())
 
 	err := proxy.Route(proxyServer, "settings/{deviceID}", proxy.Config{
 		Resolve: func(_ string) (string, string, error) {
@@ -1628,17 +1645,18 @@ func TestProxyAuditGatesRoute(t *testing.T) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	require.Equal(t, http.StatusUnauthorized, resp.StatusCode,
-		"Audit returning false must reject proxied Route requests")
-	require.False(t, upstreamHit.Load(), "upstream must not be contacted when Audit denies")
+		"middleware returning 401 must reject proxied Route requests")
+	require.False(t, upstreamHit.Load(), "upstream must not be contacted when middleware denies")
 }
 
-// TestProxyAuditGatesRouteList asserts the same for the list-shaped
-// registrar — exercises BOTH closures it installs: itemHandler at the
-// glob-expanded path and listHandler at the trimmed base path. A
-// glob-suffix localPath ("items/*") is required so basePath strips to
-// "items" and the request to /items actually matches the listHandler
-// route instead of falling through to the data wildcard.
-func TestProxyAuditGatesRouteList(t *testing.T) {
+// TestProxyMiddlewareGatesRouteList asserts the same for the
+// list-shaped registrar — exercises BOTH closures it installs:
+// itemHandler at the glob-expanded path and listHandler at the
+// trimmed base path. A glob-suffix localPath ("items/*") is required
+// so basePath strips to "items" and the request to /items actually
+// matches the listHandler route instead of falling through to the
+// data wildcard.
+func TestProxyMiddlewareGatesRouteList(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Parallel()
 	}
@@ -1652,7 +1670,8 @@ func TestProxyAuditGatesRouteList(t *testing.T) {
 
 	proxyServer := &ooo.Server{}
 	proxyServer.Silence = true
-	proxyServer.Audit = func(r *http.Request) bool { return false }
+	proxyServer.Router = mux.NewRouter()
+	proxyServer.Router.Use(denyAllMiddleware())
 
 	err := proxy.RouteList(proxyServer, "items/*", proxy.Config{
 		Resolve: func(_ string) (string, string, error) {
@@ -1668,29 +1687,29 @@ func TestProxyAuditGatesRouteList(t *testing.T) {
 	require.NoError(t, err)
 	resp.Body.Close()
 	require.Equal(t, http.StatusUnauthorized, resp.StatusCode,
-		"itemHandler must be gated by Audit")
+		"itemHandler must be gated by middleware")
 
 	// listHandler — registered at /items (basePath). This request
 	// matches the registered route directly (not the data wildcard),
-	// so the 401 must come from the listHandler's AuditHandler wrap.
+	// so the 401 must come from the middleware chain.
 	resp, err = http.Get("http://" + proxyServer.Address + "/items")
 	require.NoError(t, err)
 	resp.Body.Close()
 	require.Equal(t, http.StatusUnauthorized, resp.StatusCode,
-		"listHandler must be gated by Audit")
+		"listHandler must be gated by middleware")
 
-	require.False(t, upstreamHit.Load(), "upstream must not be contacted when Audit denies")
+	require.False(t, upstreamHit.Load(), "upstream must not be contacted when middleware denies")
 }
 
-// TestProxyAuditGatesWebSocketUpgrade asserts that the AuditHandler
-// wrap runs BEFORE the proxy closure's websocket.IsWebSocketUpgrade
-// branch. A WebSocket dial against a deny-everything Audit must
-// receive a clean HTTP 401 before any upgrade is attempted, so the
-// client never enters a half-upgraded state. The structural
-// guarantee comes from AuditHandler being the outer wrapper; this
-// test locks that ordering against future refactors that might move
-// the gate inside the inner closure.
-func TestProxyAuditGatesWebSocketUpgrade(t *testing.T) {
+// TestProxyMiddlewareGatesWebSocketUpgrade asserts that the
+// Router.Use() middleware chain runs BEFORE the proxy closure's
+// websocket.IsWebSocketUpgrade branch. A WebSocket dial against a
+// deny-all middleware must receive a clean HTTP 401 before any
+// upgrade is attempted, so the client never enters a half-upgraded
+// state. gorilla/mux's Match builds the middleware chain into the
+// matched handler, so this ordering is structural; this test locks
+// it against future refactors.
+func TestProxyMiddlewareGatesWebSocketUpgrade(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Parallel()
 	}
@@ -1704,7 +1723,8 @@ func TestProxyAuditGatesWebSocketUpgrade(t *testing.T) {
 
 	proxyServer := &ooo.Server{}
 	proxyServer.Silence = true
-	proxyServer.Audit = func(r *http.Request) bool { return false }
+	proxyServer.Router = mux.NewRouter()
+	proxyServer.Router.Use(denyAllMiddleware())
 
 	err := proxy.Route(proxyServer, "settings/{deviceID}", proxy.Config{
 		Resolve: func(_ string) (string, string, error) {
@@ -1717,7 +1737,7 @@ func TestProxyAuditGatesWebSocketUpgrade(t *testing.T) {
 
 	u := url.URL{Scheme: "ws", Host: proxyServer.Address, Path: "/settings/device1"}
 	c, resp, err := websocket.DefaultDialer.Dial(u.String(), nil)
-	require.Error(t, err, "deny-everything Audit must reject the upgrade")
+	require.Error(t, err, "deny-all middleware must reject the upgrade")
 	if c != nil {
 		c.Close()
 	}
@@ -1727,8 +1747,9 @@ func TestProxyAuditGatesWebSocketUpgrade(t *testing.T) {
 	require.False(t, upstreamHit.Load())
 }
 
-// TestProxyAuditGatesRouteWithVars asserts the same for RouteWithVars.
-func TestProxyAuditGatesRouteWithVars(t *testing.T) {
+// TestProxyMiddlewareGatesRouteWithVars asserts the same for
+// RouteWithVars.
+func TestProxyMiddlewareGatesRouteWithVars(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Parallel()
 	}
@@ -1742,7 +1763,8 @@ func TestProxyAuditGatesRouteWithVars(t *testing.T) {
 
 	proxyServer := &ooo.Server{}
 	proxyServer.Silence = true
-	proxyServer.Audit = func(r *http.Request) bool { return false }
+	proxyServer.Router = mux.NewRouter()
+	proxyServer.Router.Use(denyAllMiddleware())
 	// RouteWithVars assumes Router is initialized.
 	proxyServer.Start("localhost:0")
 	defer proxyServer.Close(os.Interrupt)

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -879,7 +879,7 @@ func TestProxyWebSocketWithBearerTokenAuthRequired(t *testing.T) {
 	remote.Start("localhost:0")
 	defer remote.Close(os.Interrupt)
 
-	// Set initial data on remote (direct storage access bypasses Audit)
+	// Set initial data on remote (direct storage access bypasses middleware)
 	data, _ := json.Marshal(Settings{Name: "protected", Value: 42})
 	_, err := remote.Storage.Set("settings", data)
 	require.NoError(t, err)

--- a/rest.go
+++ b/rest.go
@@ -19,12 +19,6 @@ import (
 )
 
 func (server *Server) publish(w http.ResponseWriter, r *http.Request) {
-	if !server.Audit(r) {
-		w.WriteHeader(http.StatusUnauthorized)
-		fmt.Fprintf(w, "%s", ErrNotAuthorized)
-		return
-	}
-
 	_key := mux.Vars(r)["key"]
 	if !key.IsValid(_key) {
 		w.WriteHeader(http.StatusBadRequest)
@@ -78,12 +72,6 @@ func (server *Server) publish(w http.ResponseWriter, r *http.Request) {
 }
 
 func (server *Server) patch(w http.ResponseWriter, r *http.Request) {
-	if !server.Audit(r) {
-		w.WriteHeader(http.StatusUnauthorized)
-		fmt.Fprintf(w, "%s", ErrNotAuthorized)
-		return
-	}
-
 	_key := mux.Vars(r)["key"]
 	if !key.IsValid(_key) {
 		w.WriteHeader(http.StatusBadRequest)
@@ -176,12 +164,6 @@ func (server *Server) read(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !server.Audit(r) {
-		w.WriteHeader(http.StatusUnauthorized)
-		fmt.Fprintf(w, "%s", ErrNotAuthorized)
-		return
-	}
-
 	if r.Header.Get("Upgrade") == "websocket" {
 		err := server.ws(w, r)
 		if err != nil {
@@ -220,12 +202,6 @@ func (server *Server) unpublish(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !server.Audit(r) {
-		w.WriteHeader(http.StatusUnauthorized)
-		fmt.Fprintf(w, "%s", ErrNotAuthorized)
-		return
-	}
-
 	err := server.filters.Delete.Check(_key, server.Static)
 	if err != nil {
 		server.Console.Err("detError["+_key+"]", err)
@@ -260,9 +236,11 @@ func (server *Server) unpublish(w http.ResponseWriter, r *http.Request) {
 // signals the response writer side-channel to suppress connection keep-alive
 // once the cap trips, and that side-channel is a no-op after the header has
 // been committed. Today both REST callers (publish, patch) short-circuit on
-// auth and key checks without writing to w first, so the invariant holds —
-// refactor that path with care. Same constraint applies to any other caller
-// (proxy handlers, custom Endpoints).
+// key checks without writing to w first, so the invariant holds — refactor
+// that path with care. Same constraint applies to any other caller (proxy
+// handlers, custom Endpoints). Auth gating via Router.Use() middleware also
+// runs before LimitBody is reached, but middleware that writes a denial
+// response into w must do so before any caller invokes LimitBody.
 //
 // The returned ReadErrorProbe (non-nil only when the cap is active) records
 // the most recent error returned by Read. benitogf/go-json is known to

--- a/rest.go
+++ b/rest.go
@@ -238,9 +238,10 @@ func (server *Server) unpublish(w http.ResponseWriter, r *http.Request) {
 // been committed. Today both REST callers (publish, patch) short-circuit on
 // key checks without writing to w first, so the invariant holds — refactor
 // that path with care. Same constraint applies to any other caller (proxy
-// handlers, custom Endpoints). Auth gating via Router.Use() middleware also
-// runs before LimitBody is reached, but middleware that writes a denial
-// response into w must do so before any caller invokes LimitBody.
+// handlers, custom Endpoints). Router.Use() middleware that denies a request
+// must short-circuit (not call next) — once next runs, the handler may
+// invoke LimitBody, and any subsequent write to w from a deferred middleware
+// closure would arrive too late.
 //
 // The returned ReadErrorProbe (non-nil only when the cap is active) records
 // the most recent error returned by Read. benitogf/go-json is known to

--- a/rest_test.go
+++ b/rest_test.go
@@ -16,8 +16,23 @@ import (
 	"github.com/benitogf/ooo/meta"
 	"github.com/benitogf/ooo/oootest"
 	"github.com/benitogf/ooo/storage"
+	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/require"
 )
+
+// denyMethodMiddleware rejects requests whose HTTP method matches
+// `method` with 401 Unauthorized; everything else passes through.
+func denyMethodMiddleware(method string) mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == method {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
 
 // maskedNotFound wraps storage.ErrNotFound but its Error() text omits
 // the literal "not found" substring. Used to exercise unpublish's
@@ -608,9 +623,8 @@ func TestRestPatchUnauthorized(t *testing.T) {
 	}
 	server := ooo.Server{}
 	server.Silence = true
-	server.Audit = func(r *http.Request) bool {
-		return r.Method != "PATCH"
-	}
+	server.Router = mux.NewRouter()
+	server.Router.Use(denyMethodMiddleware("PATCH"))
 	server.Start("localhost:0")
 	defer server.Close(os.Interrupt)
 
@@ -684,9 +698,8 @@ func TestRestReadUnauthorized(t *testing.T) {
 	}
 	server := ooo.Server{}
 	server.Silence = true
-	server.Audit = func(r *http.Request) bool {
-		return r.Method != "GET"
-	}
+	server.Router = mux.NewRouter()
+	server.Router.Use(denyMethodMiddleware("GET"))
 	server.Start("localhost:0")
 	defer server.Close(os.Interrupt)
 
@@ -728,9 +741,8 @@ func TestRestUnpublishUnauthorized(t *testing.T) {
 	}
 	server := ooo.Server{}
 	server.Silence = true
-	server.Audit = func(r *http.Request) bool {
-		return r.Method != "DELETE"
-	}
+	server.Router = mux.NewRouter()
+	server.Router.Use(denyMethodMiddleware("DELETE"))
 	server.Start("localhost:0")
 	defer server.Close(os.Interrupt)
 

--- a/samples/jwt_auth/main.go
+++ b/samples/jwt_auth/main.go
@@ -6,7 +6,7 @@
 
 // Package main demonstrates JWT authentication with auth package.
 // This example shows how to:
-// - Add JWT authentication to ooo server
+// - Add JWT authentication to ooo server via Router.Use() middleware
 // - Protect routes with token verification
 // - Handle user registration and login
 // - Use layered storage with ko for persistent user data
@@ -44,21 +44,32 @@ func main() {
 	// Create server with static mode
 	server := ooo.Server{Static: true}
 
-	// Audit middleware - check JWT for protected routes
-	server.Audit = func(r *http.Request) bool {
-		// Public routes
-		if r.URL.Path == "/register" || r.URL.Path == "/authorize" {
-			return true
-		}
-		// Protected routes require valid token
-		return tokenAuth.Verify(r)
-	}
+	// Initialize router so we can attach middleware and the auth routes
+	// before Start. Router.Use() is the documented gate — middleware
+	// fans out to every matched request via gorilla/mux's Match.
+	server.Router = mux.NewRouter()
+
+	// Auth middleware: allow login/register without a token; everything
+	// else requires a valid JWT.
+	server.Router.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/register" || r.URL.Path == "/authorize" {
+				next.ServeHTTP(w, r)
+				return
+			}
+			if !tokenAuth.Verify(r) {
+				w.WriteHeader(http.StatusUnauthorized)
+				w.Write([]byte("not authorized"))
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	})
 
 	// Enable data routes
 	server.OpenFilter("data/*")
 
 	// Add auth routes (/register, /authorize, /verify)
-	server.Router = mux.NewRouter()
 	tokenAuth.Routes(&server)
 
 	server.Start("0.0.0.0:8800")

--- a/samples/static_routes_filters_audit/README.md
+++ b/samples/static_routes_filters_audit/README.md
@@ -1,3 +1,4 @@
-# Static Routes, Filters & Audit
+# Static Routes, Filters & Middleware
 
 Static mode, write/read/delete filters, and API key authentication
+via Router.Use() middleware

--- a/samples/static_routes_filters_audit/main.go
+++ b/samples/static_routes_filters_audit/main.go
@@ -1,7 +1,7 @@
-// Package main demonstrates static routes, filters, and audit middleware.
-// This example shows how to:
+// Package main demonstrates static routes, filters, and request gating
+// via Router.Use() middleware. This example shows how to:
 // - Enable static mode (only filtered routes available)
-// - Add API key authentication via Audit
+// - Add API key authentication via Router.Use() middleware
 // - Use write filters for validation
 // - Use read filters to hide sensitive data
 // - Use delete filters to protect resources
@@ -15,6 +15,7 @@ import (
 
 	"github.com/benitogf/ooo"
 	"github.com/benitogf/ooo/meta"
+	"github.com/gorilla/mux"
 )
 
 type Book struct {
@@ -26,10 +27,23 @@ type Book struct {
 func main() {
 	server := ooo.Server{Static: true}
 
-	// Only allow requests that carry a valid API key
-	server.Audit = func(r *http.Request) bool {
-		return r.Header.Get("X-API-Key") == "secret"
-	}
+	// Initialize router so we can attach middleware before Start.
+	server.Router = mux.NewRouter()
+
+	// Only allow requests that carry a valid API key. Router.Use()
+	// middleware fans out to every matched request via gorilla/mux's
+	// Match — REST handlers, WebSocket upgrades, custom endpoints,
+	// proxy routes, and the explorer UI all run after the chain.
+	server.Router.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("X-API-Key") != "secret" {
+				w.WriteHeader(http.StatusUnauthorized)
+				w.Write([]byte("not authorized"))
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	})
 
 	// Make the list route available while Static mode is enabled
 	server.OpenFilter("books/*")

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -149,7 +149,6 @@ type Handler struct {
 	GetEndpoints   func() []EndpointInfo
 	GetProxies     func() []ProxyInfo
 	GetOrphanKeys  func() []string
-	AuditFunc      func(r *http.Request) bool
 	ClockFunc      func(w http.ResponseWriter, r *http.Request)
 }
 
@@ -160,13 +159,6 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if h.ClockFunc != nil {
 			h.ClockFunc(w, r)
 		}
-		return
-	}
-
-	// Check authorization
-	if h.AuditFunc != nil && !h.AuditFunc(r) {
-		w.WriteHeader(http.StatusUnauthorized)
-		w.Write([]byte("not authorized"))
 		return
 	}
 


### PR DESCRIPTION
## Summary
Closes #146 — `Server.Audit` and its companions are gone; consumers gate
requests by registering middleware on `server.Router.Use(...)`.

- The bool-returning `Server.Audit` hook, `AuditHandler`, and the
  explorer's `AuditFunc` are removed from the public API.
- Built-in REST handlers, WebSocket upgrades, custom endpoints, proxy
  routes, and the explorer UI all dispatch through the standard
  gorilla/mux middleware chain — one extension point, no parallel
  mechanisms.
- The JWT auth sample and the static-routes/filters sample demonstrate
  the middleware-based pattern.
- An internal doc comment that claimed `Router.Use()` middlewares were
  silently dropped on dispatch is corrected — gorilla/mux's `Match`
  builds the chain into the matched handler before returning, so
  middleware already fans out today. The PR removes the redundant
  parallel mechanism rather than adding new machinery.

## Known non-blockers folded into the PR
- The sample directory name `samples/static_routes_filters_audit/` is
  intentionally left in place — the heading and code inside have been
  updated, but renaming the directory would break any external links.
  Future cosmetic rename is fair game.
- The exported `ErrNotAuthorized` sentinel is kept for consumers who
  want to return it from their own middleware. Drop it later if no
  external consumer adopts it.

## Test plan
- [ ] `go test ./...` passes (verified locally, race + non-race).
- [ ] `go vet ./...` clean.
- [ ] No production code path still references `Server.Audit`,
      `AuditHandler`, or `AuditFunc`.
- [ ] The JWT sample boots and rejects unauthenticated requests to
      `/data/*` while allowing `/register` and `/authorize`.
- [ ] The static-routes sample rejects requests without the
      `X-API-Key: secret` header on every dispatched path (REST,
      explorer UI, custom endpoints).
- [ ] WebSocket subscriptions are gated by the middleware chain — a
      deny-all middleware refuses the upgrade cleanly with 401, no
      half-upgraded connections.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)