### PR TITLE
feat(storage): opt-in lossless watch delivery + stop watch workers on shutdown

### DIFF
--- a/ooo.go
+++ b/ooo.go
@@ -244,9 +244,15 @@ type Server struct {
 	Workers         int
 	ForcePatch      bool
 	NoPatch         bool
-	OnSubscribe     stream.Subscribe
-	OnUnsubscribe   stream.Unsubscribe
-	OnStart         func()
+	// LosslessWatch makes storage→broadcast event delivery block instead of
+	// dropping after SEND_TIMEOUT when a consumer stalls (see
+	// storage.Options.LosslessWatch). Default false keeps production drop
+	// resilience; set true for deterministic tests where a dropped broadcast
+	// would desync a subscriber.
+	LosslessWatch bool
+	OnSubscribe   stream.Subscribe
+	OnUnsubscribe stream.Unsubscribe
+	OnStart       func()
 	// OnClose runs as the final teardown step, after every PostShutdown
 	// hook. Deprecated: use RegisterCloseHook(PostShutdown, fn) instead;
 	// the field is kept for backwards compatibility and runs last so
@@ -472,6 +478,7 @@ func (server *Server) waitListen() {
 	storageOpt := storage.Options{
 		NoBroadcastKeys: server.NoBroadcastKeys,
 		Workers:         server.Workers,
+		LosslessWatch:   server.LosslessWatch,
 	}
 
 	if server.BeforeRead != nil {

--- a/storage/afterwriteop_test.go
+++ b/storage/afterwriteop_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"encoding/json"
 	"sync"
 	"testing"
@@ -114,7 +115,7 @@ func TestAfterWriteOpFiresBeforeEvent(t *testing.T) {
 	defer st.Close()
 
 	events := make(chan Event, 1)
-	WatchWithCallback(st, func(ev Event) {
+	WatchWithCallback(context.Background(), st, func(ev Event) {
 		select {
 		case events <- ev:
 		default:

--- a/storage/layered.go
+++ b/storage/layered.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"sort"
 	"sync"
 
@@ -110,6 +111,7 @@ func (l *Layered) Start(opt Options) error {
 		workers = 6
 	}
 	l.watcher = NewShardedChan(workers)
+	l.watcher.SetBlocking(opt.LosslessWatch)
 	l.noBroadcastKeys = opt.NoBroadcastKeys
 	l.beforeRead = opt.BeforeRead
 	l.afterWrite = opt.AfterWrite
@@ -834,7 +836,16 @@ func (l *Layered) sendEvent(event Event) {
 // WatchWithCallback starts goroutines that watch all sharded channels and call
 // the provided callback for each event. Use this for external storages that need
 // to trigger sync on storage events.
-func WatchWithCallback(dataStore Database, callback func(Event)) {
+//
+// The goroutines exit when any of: ctx is cancelled, the watch channel is closed
+// (storage Close), or the storage goes inactive. Passing a cancellable ctx lets
+// a caller stop the watchers without closing a storage it does not own — without
+// it the goroutines block on the channel receive until process exit, leaking one
+// per shard per call (which accumulates fast under repeated attach/detach).
+func WatchWithCallback(ctx context.Context, dataStore Database, callback func(Event)) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	shardedWatcher := dataStore.WatchSharded()
 	if shardedWatcher == nil {
 		return
@@ -842,11 +853,15 @@ func WatchWithCallback(dataStore Database, callback func(Event)) {
 	for i := 0; i < shardedWatcher.Count(); i++ {
 		go func(ch StorageChan) {
 			for {
-				event, ok := <-ch
-				if !ok || !dataStore.Active() {
+				select {
+				case <-ctx.Done():
 					return
+				case event, ok := <-ch:
+					if !ok || !dataStore.Active() {
+						return
+					}
+					callback(event)
 				}
-				callback(event)
 			}
 		}(shardedWatcher.Shard(i))
 	}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -53,14 +53,40 @@ type Options struct {
 	// storage read-back cannot determine race-free.
 	AfterWriteOp func(key string, op string)
 	Workers      int
+	// LosslessWatch makes watch-event sends block until the consumer accepts
+	// them instead of dropping after SEND_TIMEOUT. Default false keeps the
+	// production behavior (drop a stuck/dead consumer's event to prevent a
+	// permanent write hang).
+	//
+	// Enable it only where lossless delivery is required AND the consumer cannot
+	// stall indefinitely. The tradeoff is real and wider than "the writer
+	// blocks": the watch send runs while the storage holds its internal lock, so
+	// a permanently stuck consumer wedges the whole storage instance — every
+	// mutex-guarded operation, Close included, blocks behind it. The default
+	// drop mode bounds that to SEND_TIMEOUT. Typical use is deterministic tests,
+	// where a dropped broadcast would desync a subscriber and surface as a flaky
+	// hang, and the consumer is the test's own live subscriber.
+	LosslessWatch bool
 }
 
 // ShardedChan manages multiple channels for per-key ordering.
 type ShardedChan struct {
-	shards  []StorageChan
-	count   int
-	dropped atomic.Int64
-	onDrop  atomic.Pointer[func(Event)]
+	shards   []StorageChan
+	count    int
+	dropped  atomic.Int64
+	onDrop   atomic.Pointer[func(Event)]
+	blocking atomic.Bool
+	// sendTimeout is the drop-mode send deadline in nanoseconds; defaults to
+	// SEND_TIMEOUT. Configurable so tests can force the drop path quickly
+	// instead of waiting out the production timeout.
+	sendTimeout atomic.Int64
+}
+
+// SetBlocking switches the channel between drop-on-timeout (false, default) and
+// lossless blocking send (true). In blocking mode Send waits for the consumer
+// instead of dropping after SEND_TIMEOUT — see Options.LosslessWatch.
+func (s *ShardedChan) SetBlocking(blocking bool) {
+	s.blocking.Store(blocking)
 }
 
 // NewShardedChan creates a new sharded storage channel with the given number of shards.
@@ -72,10 +98,12 @@ func NewShardedChan(shardCount int) *ShardedChan {
 	for i := range shards {
 		shards[i] = make(StorageChan, 100)
 	}
-	return &ShardedChan{
+	sc := &ShardedChan{
 		shards: shards,
 		count:  shardCount,
 	}
+	sc.sendTimeout.Store(int64(SEND_TIMEOUT))
+	return sc
 }
 
 // Dropped returns the total number of events the sharded channel has dropped
@@ -124,9 +152,15 @@ func (s *ShardedChan) SendWithTimeout(event Event, timeout time.Duration) bool {
 }
 
 // Send routes an event to the appropriate shard based on key hash.
-// Uses SEND_TIMEOUT to prevent permanent blocking if the shard consumer is stuck.
+// Uses SEND_TIMEOUT to prevent permanent blocking if the shard consumer is
+// stuck — unless blocking mode is set (SetBlocking), in which case it sends
+// losslessly, waiting for the consumer rather than dropping the event.
 func (s *ShardedChan) Send(event Event) {
-	s.SendWithTimeout(event, SEND_TIMEOUT)
+	if s.blocking.Load() {
+		s.shards[s.ShardFor(event.Key)] <- event
+		return
+	}
+	s.SendWithTimeout(event, time.Duration(s.sendTimeout.Load()))
 }
 
 // ShardFor returns the shard index for a given key using FNV-1a hash.

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1,8 +1,10 @@
 package storage
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -380,7 +382,7 @@ func TestWatchWithCallback(t *testing.T) {
 	var wg sync.WaitGroup
 
 	// Start watching with callback
-	WatchWithCallback(storage, func(event Event) {
+	WatchWithCallback(context.Background(), storage, func(event Event) {
 		mu.Lock()
 		events = append(events, event)
 		mu.Unlock()
@@ -421,6 +423,147 @@ func TestWatchWithCallback(t *testing.T) {
 	require.Equal(t, 2, setCount, "should have 2 set events")
 	require.Equal(t, 1, delCount, "should have 1 delete event")
 	mu.Unlock()
+}
+
+// fillShard sends n events keyed to the same shard (so they all land in one
+// 100-deep buffer) on a non-blocking, generous-timeout channel — used to fill
+// the buffer before exercising the full-buffer behavior.
+func fillShard(s *ShardedChan, n int) {
+	for range n {
+		s.Send(Event{Key: "k", Operation: "set"})
+	}
+}
+
+// TestShardedChanBlockingSendBlocksInsteadOfDropping is the direct proof of the
+// lossless feature: with blocking set, a Send into a full shard buffer BLOCKS
+// until the consumer drains, rather than dropping after the timeout. Delete the
+// blocking branch in Send and this test fails — the send would drop and the
+// drained-and-unblocked assertions would not hold. No consumer goroutine and no
+// real timeout wait: the buffer is filled directly and the full-buffer Send is
+// observed to block, then to complete after a single receive.
+func TestShardedChanBlockingSendBlocksInsteadOfDropping(t *testing.T) {
+	t.Parallel()
+
+	s := NewShardedChan(1)
+	s.SetBlocking(true)
+	// A short drop-mode timeout would make a *non*-blocking Send drop almost
+	// immediately — so if blocking were not in effect, `done` would close fast.
+	s.sendTimeout.Store(int64(50 * time.Millisecond))
+
+	fillShard(s, 100) // buffer (cap 100) now full, nothing dropped
+	require.Equal(t, int64(0), s.Dropped())
+
+	done := make(chan struct{})
+	go func() {
+		s.Send(Event{Key: "k", Operation: "set"}) // full buffer → must block
+		close(done)
+	}()
+
+	// It must still be blocked well past the drop-mode timeout (negative
+	// assertion: a dropping Send would have returned by now).
+	select {
+	case <-done:
+		t.Fatal("blocking Send returned while buffer full — it dropped instead of blocking")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	<-s.Shard(0) // drain one slot
+	select {
+	case <-done: // blocked Send now completes
+	case <-time.After(2 * time.Second):
+		t.Fatal("blocking Send did not complete after the buffer drained")
+	}
+	require.Equal(t, int64(0), s.Dropped(), "blocking mode must never drop")
+}
+
+// TestShardedChanDropModeDropsWhenFull is the contrast that proves the above
+// setup genuinely overflows the buffer: in the default (non-blocking) mode a
+// Send into a full buffer drops after the (here shortened) timeout.
+func TestShardedChanDropModeDropsWhenFull(t *testing.T) {
+	t.Parallel()
+
+	s := NewShardedChan(1) // blocking defaults to false
+	s.sendTimeout.Store(int64(20 * time.Millisecond))
+
+	fillShard(s, 100) // fill the buffer
+	require.Equal(t, int64(0), s.Dropped())
+
+	s.Send(Event{Key: "k", Operation: "set"}) // full → drops after the timeout
+	require.Equal(t, int64(1), s.Dropped(), "drop mode must drop into a full buffer")
+}
+
+// TestLosslessWatchDeliversAllEvents is the integration-level check: through the
+// server-facing path (Options.LosslessWatch → Layered → watcher), every produced
+// event reaches the WatchWithCallback consumer. wg.Add(n) is the exact-count
+// barrier; a dropped event would leave it short and hang under -timeout.
+func TestLosslessWatchDeliversAllEvents(t *testing.T) {
+	t.Parallel()
+
+	st := New(LayeredConfig{Memory: NewMemoryLayer()})
+	require.NoError(t, st.Start(Options{LosslessWatch: true, Workers: 1}))
+	defer st.Close()
+
+	const n = 300
+	var wg sync.WaitGroup
+	wg.Add(n)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	WatchWithCallback(ctx, st, func(Event) { wg.Done() })
+
+	for i := range n {
+		_, err := st.Set(fmt.Sprintf("test/%d", i), testData)
+		require.NoError(t, err)
+	}
+	wg.Wait() // every write delivered
+	require.Equal(t, int64(0), st.watcher.Dropped())
+}
+
+// TestWatchWithCallbackContextCancelStopsGoroutines verifies the leak fix: the
+// watcher goroutines exit when the context is cancelled, even though the storage
+// is never closed (the caller may not own it). Without the ctx, each goroutine
+// blocks on its channel receive until process exit — leaking one per shard.
+// This is goroutine-leak accounting (runtime state), not async-event sync.
+func TestWatchWithCallbackContextCancelStopsGoroutines(t *testing.T) {
+	st := New(LayeredConfig{Memory: NewMemoryLayer()})
+	require.NoError(t, st.Start(Options{Workers: 8}))
+	defer st.Close()
+
+	runtime.GC()
+	base := runtime.NumGoroutine()
+	ctx, cancel := context.WithCancel(context.Background())
+	WatchWithCallback(ctx, st, func(Event) {})
+	require.Greater(t, runtime.NumGoroutine(), base, "watchers should have started")
+
+	cancel()
+	// Goroutine teardown is asynchronous; allow a bounded settle for the parked
+	// receivers to observe ctx.Done and return. This is the only sound way to
+	// observe goroutine cleanup and is not gating any business-logic event.
+	deadline := time.Now().Add(2 * time.Second)
+	for runtime.NumGoroutine() > base && time.Now().Before(deadline) {
+		runtime.Gosched()
+	}
+	require.LessOrEqual(t, runtime.NumGoroutine(), base,
+		"watcher goroutines must exit after ctx cancel (no leak)")
+}
+
+// TestWatchWithCallbackNilContext verifies a nil context is tolerated (treated
+// as never-cancel) rather than panicking on ctx.Done() — callers that construct
+// a watcher without a lifetime context still get delivery.
+func TestWatchWithCallbackNilContext(t *testing.T) {
+	t.Parallel()
+
+	st := New(LayeredConfig{Memory: NewMemoryLayer()})
+	require.NoError(t, st.Start(Options{}))
+	defer st.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	require.NotPanics(t, func() {
+		WatchWithCallback(nil, st, func(Event) { wg.Done() })
+	})
+	_, err := st.Set("test/nilctx", testData)
+	require.NoError(t, err)
+	wg.Wait() // delivery still works with a nil context
 }
 
 func TestWatchStorageNoop(t *testing.T) {


### PR DESCRIPTION
## Summary
Adds an opt-in lossless mode for real-time event delivery, and stops background watch workers from lingering after their owner shuts down. Closes #148.

## What changed
- **Opt-in lossless delivery.** When enabled, a real-time event waits for a stalled-but-live consumer instead of being dropped after the send timeout. The default is unchanged — production still drops a stuck/dead consumer's event so a slow subscriber can never permanently hang writers.
- **Watch workers stop on owner shutdown.** The storage watch helper now takes an owner lifetime signal, so its background workers exit when the owner is cancelled, not only when the store itself closes. A missing signal is treated as never-cancel (safe).

## Behavior & compatibility
- Default behavior is unchanged; lossless mode is strictly opt-in (off by default).
- **Breaking (Go API):** the exported storage watch helper now takes a context argument. In-repo callers are updated; external callers must pass one — `nil` is accepted and means never-cancel.
- Tradeoff to know: with lossless mode on, a consumer that stalls *forever* will block the storage instance (close included). It is intended only for callers whose consumer cannot stall indefinitely (e.g. test harnesses, tightly-coupled internal consumers).

## Tests
- Lossless mode provably does not drop where the default would — verified by mutation (removing the lossless branch makes the test fail), plus a contrast test showing the default drops into a full buffer.
- Watch workers exit on shutdown signal (no goroutine leak); nil-signal is handled safely.
- Full suite green under `-race`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)